### PR TITLE
human-readable diff

### DIFF
--- a/pkg/edit/diff.go
+++ b/pkg/edit/diff.go
@@ -25,6 +25,7 @@ import (
 func ShowDiff(t1 string, t2 string, w io.Writer) {
 	dmp := diffmatchpatch.New()
 	diffs := dmp.DiffMain(t1, t2, false)
+	diffs = dmp.DiffCleanupSemantic(diffs)
 
 	fmt.Fprint(w, dmp.DiffPrettyText(diffs))
 }


### PR DESCRIPTION
before:
![Screen Shot 2020-04-07 at 11 17 09 AM](https://user-images.githubusercontent.com/1681864/78626661-fd2fa200-78c1-11ea-9f96-00aa85ae1160.png)


after:
![Screen Shot 2020-04-07 at 11 16 17 AM](https://user-images.githubusercontent.com/1681864/78626674-0456b000-78c2-11ea-9925-45502e1dac36.png)

see https://github.com/google/diff-match-patch/wiki/API#diff_cleanupsemanticdiffs--null

