### PR TITLE
Revert "Rename TiFlash log level in example"

### DIFF
--- a/topology.example.yaml
+++ b/topology.example.yaml
@@ -111,7 +111,7 @@ tiflash_servers:
     # # Config is used to overwrite the `server_configs.tiflash` values
     #  config:
     #    logger:
-    #      level: "information"
+    #      level: "info"
     #  learner_config:
     #    log-level: "info"
   - host: 10.0.1.15


### PR DESCRIPTION
Reverts pingcap-incubator/tiup-cluster#202 since we have fixed it by using the same log-level names as TiDB.