### PR TITLE
Improve upgrade when there's one pd

### DIFF
--- a/pkg/api/pdapi.go
+++ b/pkg/api/pdapi.go
@@ -158,6 +158,22 @@ func (pc *PDClient) GetStores() (*pdserverapi.StoresInfo, error) {
 	return &storesInfo, nil
 }
 
+// WaitLeader wait until there's a leader or timeout.
+func (pc *PDClient) WaitLeader(timeout time.Duration) error {
+	start := time.Now()
+	for {
+		_, err := pc.GetLeader()
+		if err == nil {
+			return nil
+		}
+
+		if time.Since(start) >= timeout {
+			return err
+		}
+		time.Sleep(time.Second)
+	}
+}
+
 // GetLeader queries the leader node of PD cluster
 func (pc *PDClient) GetLeader() (*pdpb.Member, error) {
 	endpoints := pc.getEndpoints(pdLeaderURI)


### PR DESCRIPTION
1. No need to evict leader of pd.
2. Wait pd leader elected before restart kv.