### PR TITLE
*: add support of custom timeouts

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -56,7 +56,6 @@ type deployOptions struct {
 	user         string // username to login to the SSH server
 	identityFile string // path to the private key file
 	skipConfirm  bool   // skip the confirmation of topology
-	sshTimeout   int64  // timeout when connecting via SSH
 }
 
 func newDeploy() *cobra.Command {
@@ -83,7 +82,6 @@ func newDeploy() *cobra.Command {
 	cmd.Flags().StringVar(&opt.user, "user", "root", "The user name to login via SSH. The user must has root (or sudo) privilege.")
 	cmd.Flags().StringVarP(&opt.identityFile, "identity_file", "i", "", "The path of the SSH identity file. If specified, public key authentication will be used.")
 	cmd.Flags().BoolVarP(&opt.skipConfirm, "yes", "y", false, "Skip confirming the topology")
-	cmd.Flags().Int64Var(&opt.sshTimeout, "ssh-timeout", 5, "Timeout in seconds to connect host via SSH")
 
 	return cmd
 }
@@ -411,10 +409,10 @@ func deploy(clusterName, version, topoFile string, opt deployOptions) error {
 					sshConnProps.Password,
 					sshConnProps.IdentityFile,
 					sshConnProps.IdentityFilePassphrase,
-					opt.sshTimeout,
+					sshTimeout,
 				).
 				EnvInit(inst.GetHost(), globalOptions.User).
-				UserSSH(inst.GetHost(), globalOptions.User, opt.sshTimeout).
+				UserSSH(inst.GetHost(), globalOptions.User, sshTimeout).
 				Mkdir(globalOptions.User, inst.GetHost(), dirs...).
 				Chown(globalOptions.User, inst.GetHost(), dirs...).
 				Build()
@@ -466,7 +464,6 @@ func deploy(clusterName, version, topoFile string, opt deployOptions) error {
 		globalOptions,
 		topo.MonitoredOptions,
 		version,
-		opt.sshTimeout,
 	)
 	downloadCompTasks = append(downloadCompTasks, dlTasks...)
 	deployCompTasks = append(deployCompTasks, dpTasks...)
@@ -523,8 +520,7 @@ func buildMonitoredDeployTask(
 	uniqueHosts set.StringSet,
 	globalOptions meta.GlobalOptions,
 	monitoredOptions meta.MonitoredOptions,
-	version string,
-	sshTimeout int64) (downloadCompTasks []*task.StepDisplay, deployCompTasks []task.Task) {
+	version string) (downloadCompTasks []*task.StepDisplay, deployCompTasks []task.Task) {
 	for _, comp := range []string{meta.ComponentNodeExporter, meta.ComponentBlackboxExporter} {
 		version := bindversion.ComponentVersion(comp, version)
 		t := task.NewBuilder().

--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -32,7 +32,6 @@ import (
 func newDestroyCmd() *cobra.Command {
 	var (
 		skipConfirm bool
-		sshTimeout  int64
 	)
 	cmd := &cobra.Command{
 		Use:   "destroy <cluster-name>",
@@ -89,7 +88,6 @@ func newDestroyCmd() *cobra.Command {
 	}
 
 	cmd.Flags().BoolVarP(&skipConfirm, "yes", "y", false, "Skip the confirmation of destroying")
-	cmd.Flags().Int64Var(&sshTimeout, "ssh-timeout", 5, "Timeout in seconds to connect host via SSH")
 
 	return cmd
 }

--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -30,7 +30,10 @@ import (
 )
 
 func newDestroyCmd() *cobra.Command {
-	var skipConfirm bool
+	var (
+		skipConfirm bool
+		sshTimeout  int64
+	)
 	cmd := &cobra.Command{
 		Use:   "destroy <cluster-name>",
 		Short: "Destroy a specified cluster",
@@ -64,7 +67,7 @@ func newDestroyCmd() *cobra.Command {
 				SSHKeySet(
 					meta.ClusterPath(clusterName, "ssh", "id_rsa"),
 					meta.ClusterPath(clusterName, "ssh", "id_rsa.pub")).
-				ClusterSSH(metadata.Topology, metadata.User).
+				ClusterSSH(metadata.Topology, metadata.User, sshTimeout).
 				ClusterOperate(metadata.Topology, operator.StopOperation, operator.Options{}).
 				ClusterOperate(metadata.Topology, operator.DestroyOperation, operator.Options{}).
 				Build()
@@ -86,6 +89,7 @@ func newDestroyCmd() *cobra.Command {
 	}
 
 	cmd.Flags().BoolVarP(&skipConfirm, "yes", "y", false, "Skip the confirmation of destroying")
+	cmd.Flags().Int64Var(&sshTimeout, "ssh-timeout", 5, "Timeout in seconds to connect host via SSH")
 
 	return cmd
 }

--- a/cmd/display.go
+++ b/cmd/display.go
@@ -35,7 +35,6 @@ type displayOption struct {
 	clusterName string
 	filterRole  []string
 	filterNode  []string
-	sshTimeout  int64
 }
 
 func newDisplayCmd() *cobra.Command {
@@ -61,13 +60,12 @@ func newDisplayCmd() *cobra.Command {
 			if err != nil {
 				return errors.AddStack(err)
 			}
-			return destroyTombsomeIfNeed(opt.clusterName, metadata, opt.sshTimeout)
+			return destroyTombsomeIfNeed(opt.clusterName, metadata, sshTimeout)
 		},
 	}
 
 	cmd.Flags().StringSliceVarP(&opt.filterRole, "role", "R", nil, "Only display specified roles")
 	cmd.Flags().StringSliceVarP(&opt.filterNode, "node", "N", nil, "Only display specified nodes")
-	cmd.Flags().Int64Var(&opt.sshTimeout, "ssh-timeout", 5, "Timeout in seconds to connect host via SSH")
 
 	return cmd
 }
@@ -150,7 +148,7 @@ func displayClusterTopology(opt *displayOption) error {
 		return errors.AddStack(err)
 	}
 
-	err = ctx.SetClusterSSH(topo, metadata.User, opt.sshTimeout)
+	err = ctx.SetClusterSSH(topo, metadata.User, sshTimeout)
 	if err != nil {
 		return errors.AddStack(err)
 	}

--- a/cmd/display.go
+++ b/cmd/display.go
@@ -60,7 +60,7 @@ func newDisplayCmd() *cobra.Command {
 			if err != nil {
 				return errors.AddStack(err)
 			}
-			return destroyTombsomeIfNeed(opt.clusterName, metadata, sshTimeout)
+			return destroyTombsomeIfNeed(opt.clusterName, metadata)
 		},
 	}
 
@@ -88,7 +88,7 @@ func displayClusterMeta(opt *displayOption) error {
 	return nil
 }
 
-func destroyTombsomeIfNeed(clusterName string, metadata *meta.ClusterMeta, sshTimeout int64) error {
+func destroyTombsomeIfNeed(clusterName string, metadata *meta.ClusterMeta) error {
 	topo := metadata.Topology
 
 	if !operator.NeedCheckTomebsome(topo) {

--- a/cmd/display.go
+++ b/cmd/display.go
@@ -35,6 +35,7 @@ type displayOption struct {
 	clusterName string
 	filterRole  []string
 	filterNode  []string
+	sshTimeout  int64
 }
 
 func newDisplayCmd() *cobra.Command {
@@ -60,12 +61,13 @@ func newDisplayCmd() *cobra.Command {
 			if err != nil {
 				return errors.AddStack(err)
 			}
-			return destroyTombsomeIfNeed(opt.clusterName, metadata)
+			return destroyTombsomeIfNeed(opt.clusterName, metadata, opt.sshTimeout)
 		},
 	}
 
 	cmd.Flags().StringSliceVarP(&opt.filterRole, "role", "R", nil, "Only display specified roles")
 	cmd.Flags().StringSliceVarP(&opt.filterNode, "node", "N", nil, "Only display specified nodes")
+	cmd.Flags().Int64Var(&opt.sshTimeout, "ssh-timeout", 5, "Timeout in seconds to connect host via SSH")
 
 	return cmd
 }
@@ -88,7 +90,7 @@ func displayClusterMeta(opt *displayOption) error {
 	return nil
 }
 
-func destroyTombsomeIfNeed(clusterName string, metadata *meta.ClusterMeta) error {
+func destroyTombsomeIfNeed(clusterName string, metadata *meta.ClusterMeta, sshTimeout int64) error {
 	topo := metadata.Topology
 
 	if !operator.NeedCheckTomebsome(topo) {
@@ -102,7 +104,7 @@ func destroyTombsomeIfNeed(clusterName string, metadata *meta.ClusterMeta) error
 		return errors.AddStack(err)
 	}
 
-	err = ctx.SetClusterSSH(topo, metadata.User)
+	err = ctx.SetClusterSSH(topo, metadata.User, sshTimeout)
 	if err != nil {
 		return errors.AddStack(err)
 	}
@@ -148,7 +150,7 @@ func displayClusterTopology(opt *displayOption) error {
 		return errors.AddStack(err)
 	}
 
-	err = ctx.SetClusterSSH(topo, metadata.User)
+	err = ctx.SetClusterSSH(topo, metadata.User, opt.sshTimeout)
 	if err != nil {
 		return errors.AddStack(err)
 	}

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -24,9 +24,8 @@ import (
 )
 
 type execOptions struct {
-	command    string
-	sudo       bool
-	sshTimeout int64
+	command string
+	sudo    bool
 	//role string
 	//node string
 }
@@ -55,7 +54,7 @@ func newExecCmd() *cobra.Command {
 			var shellTasks []task.Task
 			metadata.Topology.IterInstance(func(inst meta.Instance) {
 				t := task.NewBuilder().
-					UserSSH(inst.GetHost(), metadata.User, opt.sshTimeout).
+					UserSSH(inst.GetHost(), metadata.User, sshTimeout).
 					Shell(inst.GetHost(), opt.command, opt.sudo).
 					Build()
 				shellTasks = append(shellTasks, t)
@@ -65,7 +64,7 @@ func newExecCmd() *cobra.Command {
 				SSHKeySet(
 					meta.ClusterPath(clusterName, "ssh", "id_rsa"),
 					meta.ClusterPath(clusterName, "ssh", "id_rsa.pub")).
-				ClusterSSH(metadata.Topology, metadata.User, opt.sshTimeout).
+				ClusterSSH(metadata.Topology, metadata.User, sshTimeout).
 				Parallel(shellTasks...).
 				Build()
 
@@ -82,7 +81,6 @@ func newExecCmd() *cobra.Command {
 
 	cmd.Flags().StringVar(&opt.command, "command", "ls", "the command run on cluster host")
 	cmd.Flags().BoolVar(&opt.sudo, "sudo", false, "use root permissions (default false)")
-	cmd.Flags().Int64Var(&opt.sshTimeout, "ssh-timeout", 5, "Timeout in seconds to connect host via SSH")
 
 	return cmd
 }

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -24,8 +24,9 @@ import (
 )
 
 type execOptions struct {
-	command string
-	sudo    bool
+	command    string
+	sudo       bool
+	sshTimeout int64
 	//role string
 	//node string
 }
@@ -54,7 +55,7 @@ func newExecCmd() *cobra.Command {
 			var shellTasks []task.Task
 			metadata.Topology.IterInstance(func(inst meta.Instance) {
 				t := task.NewBuilder().
-					UserSSH(inst.GetHost(), metadata.User).
+					UserSSH(inst.GetHost(), metadata.User, opt.sshTimeout).
 					Shell(inst.GetHost(), opt.command, opt.sudo).
 					Build()
 				shellTasks = append(shellTasks, t)
@@ -64,7 +65,7 @@ func newExecCmd() *cobra.Command {
 				SSHKeySet(
 					meta.ClusterPath(clusterName, "ssh", "id_rsa"),
 					meta.ClusterPath(clusterName, "ssh", "id_rsa.pub")).
-				ClusterSSH(metadata.Topology, metadata.User).
+				ClusterSSH(metadata.Topology, metadata.User, opt.sshTimeout).
 				Parallel(shellTasks...).
 				Build()
 
@@ -81,5 +82,7 @@ func newExecCmd() *cobra.Command {
 
 	cmd.Flags().StringVar(&opt.command, "command", "ls", "the command run on cluster host")
 	cmd.Flags().BoolVar(&opt.sudo, "sudo", false, "use root permissions (default false)")
+	cmd.Flags().Int64Var(&opt.sshTimeout, "ssh-timeout", 5, "Timeout in seconds to connect host via SSH")
+
 	return cmd
 }

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -31,7 +31,6 @@ func newImportCmd() *cobra.Command {
 		ansibleDir        string
 		inventoryFileName string
 		rename            string
-		sshTimeout        int64
 	)
 
 	cmd := &cobra.Command{
@@ -96,7 +95,6 @@ func newImportCmd() *cobra.Command {
 	cmd.Flags().StringVarP(&ansibleDir, "dir", "d", "", "The path to TiDB-Ansible directory")
 	cmd.Flags().StringVar(&inventoryFileName, "inventory", ansible.AnsibleInventoryFile, "The name of inventory file")
 	cmd.Flags().StringVarP(&rename, "rename", "r", "", "Rename the imported cluster to `NAME`")
-	cmd.Flags().Int64Var(&sshTimeout, "ssh-timeout", 5, "Timeout in seconds to connect host via SSH")
 
 	return cmd
 }

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -31,6 +31,7 @@ func newImportCmd() *cobra.Command {
 		ansibleDir        string
 		inventoryFileName string
 		rename            string
+		sshTimeout        int64
 	)
 
 	cmd := &cobra.Command{
@@ -38,7 +39,7 @@ func newImportCmd() *cobra.Command {
 		Short: "Import an exist TiDB cluster from TiDB-Ansible",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// migrate cluster metadata from Ansible inventory
-			clsName, clsMeta, err := ansible.ImportAnsible(ansibleDir, inventoryFileName)
+			clsName, clsMeta, err := ansible.ImportAnsible(ansibleDir, inventoryFileName, sshTimeout)
 			if err != nil {
 				return err
 			}
@@ -70,7 +71,7 @@ func newImportCmd() *cobra.Command {
 			}
 
 			// copy config files form deployment servers
-			if err = ansible.ImportConfig(clsName, clsMeta); err != nil {
+			if err = ansible.ImportConfig(clsName, clsMeta, sshTimeout); err != nil {
 				return err
 			}
 
@@ -95,6 +96,7 @@ func newImportCmd() *cobra.Command {
 	cmd.Flags().StringVarP(&ansibleDir, "dir", "d", "", "The path to TiDB-Ansible directory")
 	cmd.Flags().StringVar(&inventoryFileName, "inventory", ansible.AnsibleInventoryFile, "The name of inventory file")
 	cmd.Flags().StringVarP(&rename, "rename", "r", "", "Rename the imported cluster to `NAME`")
+	cmd.Flags().Int64Var(&sshTimeout, "ssh-timeout", 5, "Timeout in seconds to connect host via SSH")
 
 	return cmd
 }

--- a/cmd/reload.go
+++ b/cmd/reload.go
@@ -95,7 +95,7 @@ func buildReloadTask(
 		logDir := clusterutil.Abs(metadata.User, inst.LogDir())
 
 		// Download and copy the latest component to remote if the cluster is imported from Ansible
-		tb := task.NewBuilder().UserSSH(inst.GetHost(), metadata.User, options.Timeout)
+		tb := task.NewBuilder().UserSSH(inst.GetHost(), metadata.User, sshTimeout)
 		if inst.IsImported() {
 			switch compName := inst.ComponentName(); compName {
 			case meta.ComponentGrafana, meta.ComponentPrometheus:

--- a/cmd/reload.go
+++ b/cmd/reload.go
@@ -29,7 +29,6 @@ import (
 
 func newReloadCmd() *cobra.Command {
 	var options operator.Options
-	var sshTimeout int64
 
 	cmd := &cobra.Command{
 		Use:   "reload <cluster-name>",
@@ -50,7 +49,7 @@ func newReloadCmd() *cobra.Command {
 				return err
 			}
 
-			t, err := buildReloadTask(clusterName, metadata, options, sshTimeout)
+			t, err := buildReloadTask(clusterName, metadata, options)
 			if err != nil {
 				return err
 			}
@@ -71,7 +70,6 @@ func newReloadCmd() *cobra.Command {
 
 	cmd.Flags().StringSliceVarP(&options.Roles, "role", "R", nil, "Only start specified roles")
 	cmd.Flags().StringSliceVarP(&options.Nodes, "node", "N", nil, "Only start specified nodes")
-	cmd.Flags().Int64Var(&sshTimeout, "ssh-timeout", 5, "Timeout in seconds to connect host via SSH")
 
 	return cmd
 }
@@ -80,7 +78,6 @@ func buildReloadTask(
 	clusterName string,
 	metadata *meta.ClusterMeta,
 	options operator.Options,
-	sshTimeout int64,
 ) (task.Task, error) {
 
 	var refreshConfigTasks []task.Task

--- a/cmd/reload.go
+++ b/cmd/reload.go
@@ -29,6 +29,7 @@ import (
 
 func newReloadCmd() *cobra.Command {
 	var options operator.Options
+	var sshTimeout int64
 
 	cmd := &cobra.Command{
 		Use:   "reload <cluster-name>",
@@ -49,7 +50,7 @@ func newReloadCmd() *cobra.Command {
 				return err
 			}
 
-			t, err := buildReloadTask(clusterName, metadata, options)
+			t, err := buildReloadTask(clusterName, metadata, options, sshTimeout)
 			if err != nil {
 				return err
 			}
@@ -70,6 +71,8 @@ func newReloadCmd() *cobra.Command {
 
 	cmd.Flags().StringSliceVarP(&options.Roles, "role", "R", nil, "Only start specified roles")
 	cmd.Flags().StringSliceVarP(&options.Nodes, "node", "N", nil, "Only start specified nodes")
+	cmd.Flags().Int64Var(&sshTimeout, "ssh-timeout", 5, "Timeout in seconds to connect host via SSH")
+
 	return cmd
 }
 
@@ -77,6 +80,7 @@ func buildReloadTask(
 	clusterName string,
 	metadata *meta.ClusterMeta,
 	options operator.Options,
+	sshTimeout int64,
 ) (task.Task, error) {
 
 	var refreshConfigTasks []task.Task
@@ -94,7 +98,7 @@ func buildReloadTask(
 		logDir := clusterutil.Abs(metadata.User, inst.LogDir())
 
 		// Download and copy the latest component to remote if the cluster is imported from Ansible
-		tb := task.NewBuilder().UserSSH(inst.GetHost(), metadata.User)
+		tb := task.NewBuilder().UserSSH(inst.GetHost(), metadata.User, options.Timeout)
 		if inst.IsImported() {
 			switch compName := inst.ComponentName(); compName {
 			case meta.ComponentGrafana, meta.ComponentPrometheus:
@@ -117,7 +121,7 @@ func buildReloadTask(
 		SSHKeySet(
 			meta.ClusterPath(clusterName, "ssh", "id_rsa"),
 			meta.ClusterPath(clusterName, "ssh", "id_rsa.pub")).
-		ClusterSSH(metadata.Topology, metadata.User).
+		ClusterSSH(metadata.Topology, metadata.User, sshTimeout).
 		Parallel(refreshConfigTasks...).
 		ClusterOperate(metadata.Topology, operator.UpgradeOperation, options).
 		Build()

--- a/cmd/restart.go
+++ b/cmd/restart.go
@@ -27,7 +27,6 @@ import (
 
 func newRestartCmd() *cobra.Command {
 	var options operator.Options
-	var sshTimeout int64
 
 	cmd := &cobra.Command{
 		Use:   "restart <cluster-name>",
@@ -72,6 +71,5 @@ func newRestartCmd() *cobra.Command {
 
 	cmd.Flags().StringSliceVarP(&options.Roles, "role", "R", nil, "Only restart specified roles")
 	cmd.Flags().StringSliceVarP(&options.Nodes, "node", "N", nil, "Only restart specified nodes")
-	cmd.Flags().Int64Var(&sshTimeout, "ssh-timeout", 5, "Timeout in seconds to connect host via SSH")
 	return cmd
 }

--- a/cmd/restart.go
+++ b/cmd/restart.go
@@ -27,6 +27,7 @@ import (
 
 func newRestartCmd() *cobra.Command {
 	var options operator.Options
+	var sshTimeout int64
 
 	cmd := &cobra.Command{
 		Use:   "restart <cluster-name>",
@@ -51,7 +52,7 @@ func newRestartCmd() *cobra.Command {
 				SSHKeySet(
 					meta.ClusterPath(clusterName, "ssh", "id_rsa"),
 					meta.ClusterPath(clusterName, "ssh", "id_rsa.pub")).
-				ClusterSSH(metadata.Topology, metadata.User).
+				ClusterSSH(metadata.Topology, metadata.User, sshTimeout).
 				ClusterOperate(metadata.Topology, operator.RestartOperation, options).
 				Build()
 
@@ -71,5 +72,6 @@ func newRestartCmd() *cobra.Command {
 
 	cmd.Flags().StringSliceVarP(&options.Roles, "role", "R", nil, "Only restart specified roles")
 	cmd.Flags().StringSliceVarP(&options.Nodes, "node", "N", nil, "Only restart specified nodes")
+	cmd.Flags().Int64Var(&sshTimeout, "ssh-timeout", 5, "Timeout in seconds to connect host via SSH")
 	return cmd
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -38,7 +38,8 @@ import (
 var rootCmd *cobra.Command
 
 var (
-	errNS = errorx.NewNamespace("cmd")
+	errNS      = errorx.NewNamespace("cmd")
+	sshTimeout int64 // timeout in seconds when connecting an SSH server
 )
 
 func init() {
@@ -74,6 +75,8 @@ func init() {
 	}
 
 	beautifyCobraUsageAndHelp(rootCmd)
+
+	rootCmd.PersistentFlags().Int64Var(&sshTimeout, "ssh-timeout", 5, "Timeout in seconds to connect host via SSH, ignored for operations that don't need an SSH connection.")
 
 	rootCmd.AddCommand(
 		newDeploy(),

--- a/cmd/scale_in.go
+++ b/cmd/scale_in.go
@@ -36,7 +36,6 @@ func newScaleInCmd() *cobra.Command {
 	var (
 		options     operator.Options
 		skipConfirm bool
-		sshTimeout  int64
 	)
 	cmd := &cobra.Command{
 		Use:   "scale-in <cluster-name>",
@@ -58,21 +57,20 @@ func newScaleInCmd() *cobra.Command {
 			}
 
 			logger.EnableAuditLog()
-			return scaleIn(clusterName, options, sshTimeout)
+			return scaleIn(clusterName, options)
 		},
 	}
 
 	cmd.Flags().StringSliceVarP(&options.Nodes, "node", "N", nil, "Specify the nodes")
 	cmd.Flags().BoolVarP(&skipConfirm, "yes", "y", false, "Skip the confirmation of destroying")
 	cmd.Flags().Int64Var(&options.Timeout, "transfer-timeout", 300, "Timeout in seconds when transferring PD and TiKV store leaders")
-	cmd.Flags().Int64Var(&sshTimeout, "ssh-timeout", 5, "Timeout in seconds to connect host via SSH")
 
 	_ = cmd.MarkFlagRequired("node")
 
 	return cmd
 }
 
-func scaleIn(clusterName string, options operator.Options, sshTimeout int64) error {
+func scaleIn(clusterName string, options operator.Options) error {
 	if tiuputils.IsNotExist(meta.ClusterPath(clusterName, meta.MetaFileName)) {
 		return errors.Errorf("cannot scale-in non-exists cluster %s", clusterName)
 	}

--- a/cmd/scale_in.go
+++ b/cmd/scale_in.go
@@ -61,6 +61,8 @@ func newScaleInCmd() *cobra.Command {
 
 	cmd.Flags().StringSliceVarP(&options.Nodes, "node", "N", nil, "Specify the nodes")
 	cmd.Flags().BoolVarP(&skipConfirm, "yes", "y", false, "Skip the confirmation of destroying")
+	cmd.Flags().Int64Var(&options.Timeout, "transfer-timeout", 300, "Timeout in seconds when transferring PD and TiKV store leaders")
+
 	_ = cmd.MarkFlagRequired("node")
 
 	return cmd

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -27,7 +27,6 @@ import (
 
 func newStartCmd() *cobra.Command {
 	var options operator.Options
-	var sshTimeout int64
 
 	cmd := &cobra.Command{
 		Use:   "start <cluster-name>",
@@ -72,6 +71,5 @@ func newStartCmd() *cobra.Command {
 
 	cmd.Flags().StringSliceVarP(&options.Roles, "role", "R", nil, "Only start specified roles")
 	cmd.Flags().StringSliceVarP(&options.Nodes, "node", "N", nil, "Only start specified nodes")
-	cmd.Flags().Int64Var(&sshTimeout, "ssh-timeout", 5, "Timeout in seconds to connect host via SSH")
 	return cmd
 }

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -27,6 +27,7 @@ import (
 
 func newStartCmd() *cobra.Command {
 	var options operator.Options
+	var sshTimeout int64
 
 	cmd := &cobra.Command{
 		Use:   "start <cluster-name>",
@@ -51,7 +52,7 @@ func newStartCmd() *cobra.Command {
 				SSHKeySet(
 					meta.ClusterPath(clusterName, "ssh", "id_rsa"),
 					meta.ClusterPath(clusterName, "ssh", "id_rsa.pub")).
-				ClusterSSH(metadata.Topology, metadata.User).
+				ClusterSSH(metadata.Topology, metadata.User, sshTimeout).
 				ClusterOperate(metadata.Topology, operator.StartOperation, options).
 				Build()
 
@@ -71,5 +72,6 @@ func newStartCmd() *cobra.Command {
 
 	cmd.Flags().StringSliceVarP(&options.Roles, "role", "R", nil, "Only start specified roles")
 	cmd.Flags().StringSliceVarP(&options.Nodes, "node", "N", nil, "Only start specified nodes")
+	cmd.Flags().Int64Var(&sshTimeout, "ssh-timeout", 5, "Timeout in seconds to connect host via SSH")
 	return cmd
 }

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -27,6 +27,8 @@ import (
 
 func newStopCmd() *cobra.Command {
 	var options operator.Options
+	var sshTimeout int64
+
 	cmd := &cobra.Command{
 		Use:   "stop <cluster-name>",
 		Short: "Stop a TiDB cluster",
@@ -50,7 +52,7 @@ func newStopCmd() *cobra.Command {
 				SSHKeySet(
 					meta.ClusterPath(clusterName, "ssh", "id_rsa"),
 					meta.ClusterPath(clusterName, "ssh", "id_rsa.pub")).
-				ClusterSSH(metadata.Topology, metadata.User).
+				ClusterSSH(metadata.Topology, metadata.User, sshTimeout).
 				ClusterOperate(metadata.Topology, operator.StopOperation, options).
 				Build()
 
@@ -70,5 +72,6 @@ func newStopCmd() *cobra.Command {
 
 	cmd.Flags().StringSliceVarP(&options.Roles, "role", "R", nil, "Only stop specified roles")
 	cmd.Flags().StringSliceVarP(&options.Nodes, "node", "N", nil, "Only stop specified nodes")
+	cmd.Flags().Int64Var(&sshTimeout, "ssh-timeout", 5, "Timeout in seconds to connect host via SSH")
 	return cmd
 }

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -27,7 +27,6 @@ import (
 
 func newStopCmd() *cobra.Command {
 	var options operator.Options
-	var sshTimeout int64
 
 	cmd := &cobra.Command{
 		Use:   "stop <cluster-name>",
@@ -72,6 +71,5 @@ func newStopCmd() *cobra.Command {
 
 	cmd.Flags().StringSliceVarP(&options.Roles, "role", "R", nil, "Only stop specified roles")
 	cmd.Flags().StringSliceVarP(&options.Nodes, "node", "N", nil, "Only stop specified nodes")
-	cmd.Flags().Int64Var(&sshTimeout, "ssh-timeout", 5, "Timeout in seconds to connect host via SSH")
 	return cmd
 }

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -32,7 +32,8 @@ import (
 )
 
 type upgradeOptions struct {
-	options operator.Options
+	options    operator.Options
+	sshTimeout int64
 }
 
 func newUpgradeCmd() *cobra.Command {
@@ -51,6 +52,7 @@ func newUpgradeCmd() *cobra.Command {
 	}
 	cmd.Flags().BoolVar(&opt.options.Force, "force", false, "Force upgrade won't transfer leader")
 	cmd.Flags().Int64Var(&opt.options.Timeout, "transfer-timeout", 300, "Timeout in seconds when transferring PD and TiKV store leaders")
+	cmd.Flags().Int64Var(&opt.sshTimeout, "ssh-timeout", 5, "Timeout in seconds to connect host via SSH")
 
 	return cmd
 }
@@ -152,7 +154,7 @@ func upgrade(clusterName, version string, opt upgradeOptions) error {
 		SSHKeySet(
 			meta.ClusterPath(clusterName, "ssh", "id_rsa"),
 			meta.ClusterPath(clusterName, "ssh", "id_rsa.pub")).
-		ClusterSSH(metadata.Topology, metadata.User).
+		ClusterSSH(metadata.Topology, metadata.User, opt.sshTimeout).
 		Parallel(downloadCompTasks...).
 		Parallel(copyCompTasks...).
 		ClusterOperate(metadata.Topology, operator.UpgradeOperation, opt.options).

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -50,6 +50,7 @@ func newUpgradeCmd() *cobra.Command {
 		},
 	}
 	cmd.Flags().BoolVar(&opt.options.Force, "force", false, "Force upgrade won't transfer leader")
+	cmd.Flags().Int64Var(&opt.options.Timeout, "transfer-timeout", 300, "Timeout in seconds when transferring PD and TiKV store leaders")
 
 	return cmd
 }

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -32,8 +32,7 @@ import (
 )
 
 type upgradeOptions struct {
-	options    operator.Options
-	sshTimeout int64
+	options operator.Options
 }
 
 func newUpgradeCmd() *cobra.Command {
@@ -52,7 +51,6 @@ func newUpgradeCmd() *cobra.Command {
 	}
 	cmd.Flags().BoolVar(&opt.options.Force, "force", false, "Force upgrade won't transfer leader")
 	cmd.Flags().Int64Var(&opt.options.Timeout, "transfer-timeout", 300, "Timeout in seconds when transferring PD and TiKV store leaders")
-	cmd.Flags().Int64Var(&opt.sshTimeout, "ssh-timeout", 5, "Timeout in seconds to connect host via SSH")
 
 	return cmd
 }
@@ -154,7 +152,7 @@ func upgrade(clusterName, version string, opt upgradeOptions) error {
 		SSHKeySet(
 			meta.ClusterPath(clusterName, "ssh", "id_rsa"),
 			meta.ClusterPath(clusterName, "ssh", "id_rsa.pub")).
-		ClusterSSH(metadata.Topology, metadata.User, opt.sshTimeout).
+		ClusterSSH(metadata.Topology, metadata.User, sshTimeout).
 		Parallel(downloadCompTasks...).
 		Parallel(copyCompTasks...).
 		ClusterOperate(metadata.Topology, operator.UpgradeOperation, opt.options).

--- a/pkg/ansible/config.go
+++ b/pkg/ansible/config.go
@@ -24,7 +24,7 @@ import (
 )
 
 // ImportConfig copies config files from cluster which deployed through tidb-ansible
-func ImportConfig(name string, clsMeta *meta.ClusterMeta) error {
+func ImportConfig(name string, clsMeta *meta.ClusterMeta, sshTimeout int64) error {
 	// there may be already cluster dir, skip create
 	//if err := os.MkdirAll(meta.ClusterPath(name), 0755); err != nil {
 	//	return err
@@ -42,7 +42,7 @@ func ImportConfig(name string, clsMeta *meta.ClusterMeta) error {
 					SSHKeySet(
 						meta.ClusterPath(name, "ssh", "id_rsa"),
 						meta.ClusterPath(name, "ssh", "id_rsa.pub")).
-					UserSSH(inst.GetHost(), clsMeta.User).
+					UserSSH(inst.GetHost(), clsMeta.User, sshTimeout).
 					CopyFile(filepath.Join(inst.DeployDir(), "conf", inst.ComponentName()+".toml"),
 						meta.ClusterPath(name,
 							"config",
@@ -59,7 +59,7 @@ func ImportConfig(name string, clsMeta *meta.ClusterMeta) error {
 					SSHKeySet(
 						meta.ClusterPath(name, "ssh", "id_rsa"),
 						meta.ClusterPath(name, "ssh", "id_rsa.pub")).
-					UserSSH(inst.GetHost(), clsMeta.User).
+					UserSSH(inst.GetHost(), clsMeta.User, sshTimeout).
 					CopyFile(filepath.Join(inst.DeployDir(), "conf", inst.ComponentName()+".toml"),
 						meta.ClusterPath(name,
 							"config",

--- a/pkg/ansible/dirs.go
+++ b/pkg/ansible/dirs.go
@@ -16,6 +16,7 @@ package ansible
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/pingcap-incubator/tiup-cluster/pkg/executor"
 	"github.com/pingcap-incubator/tiup-cluster/pkg/log"
@@ -29,7 +30,7 @@ var (
 )
 
 // parseDirs sets values of directories of component
-func parseDirs(host *aini.Host, ins meta.InstanceSpec) (meta.InstanceSpec, error) {
+func parseDirs(host *aini.Host, ins meta.InstanceSpec, sshTimeout int64) (meta.InstanceSpec, error) {
 	hostName, sshPort := ins.SSH()
 
 	e := executor.NewSSHExecutor(executor.SSHConfig{
@@ -37,6 +38,7 @@ func parseDirs(host *aini.Host, ins meta.InstanceSpec) (meta.InstanceSpec, error
 		Port:    sshPort,
 		User:    host.Vars["ansible_user"],
 		KeyFile: SSHKeyPath(), // ansible generated keyfile
+		Timeout: time.Second * time.Duration(sshTimeout),
 	})
 	log.Debugf("Detecting deploy paths on %s...", hostName)
 

--- a/pkg/ansible/import.go
+++ b/pkg/ansible/import.go
@@ -25,7 +25,7 @@ import (
 )
 
 // ImportAnsible imports a TiDB cluster deployed by TiDB-Ansible
-func ImportAnsible(dir, inventoryFileName string) (string, *meta.ClusterMeta, error) {
+func ImportAnsible(dir, inventoryFileName string, sshTimeout int64) (string, *meta.ClusterMeta, error) {
 	if inventoryFileName == "" {
 		inventoryFileName = AnsibleInventoryFile
 	}
@@ -41,7 +41,7 @@ func ImportAnsible(dir, inventoryFileName string) (string, *meta.ClusterMeta, er
 		return "", nil, err
 	}
 
-	clsName, clsMeta, err := parseInventory(dir, inventory)
+	clsName, clsMeta, err := parseInventory(dir, inventory, sshTimeout)
 	if err != nil {
 		return "", nil, err
 	}

--- a/pkg/ansible/inventory.go
+++ b/pkg/ansible/inventory.go
@@ -46,7 +46,7 @@ var (
 )
 
 // parseInventory builds a basic ClusterMeta from the main Ansible inventory
-func parseInventory(dir string, inv *aini.InventoryData) (string, *meta.ClusterMeta, error) {
+func parseInventory(dir string, inv *aini.InventoryData, sshTimeout int64) (string, *meta.ClusterMeta, error) {
 	topo := &meta.TopologySpecification{
 		GlobalOptions:    meta.GlobalOptions{},
 		MonitoredOptions: meta.MonitoredOptions{},
@@ -155,7 +155,7 @@ func parseInventory(dir string, inv *aini.InventoryData) (string, *meta.ClusterM
 			}
 
 			log.Debugf("Imported %s node %s:%d.", tmpIns.Role(), tmpIns.Host, tmpIns.GetMainPort())
-			ins, err := parseDirs(srv, tmpIns)
+			ins, err := parseDirs(srv, tmpIns, sshTimeout)
 			if err != nil {
 				return "", nil, err
 			}
@@ -204,7 +204,7 @@ func parseInventory(dir string, inv *aini.InventoryData) (string, *meta.ClusterM
 			}
 
 			log.Debugf("Imported %s node %s:%d.", tmpIns.Role(), tmpIns.Host, tmpIns.GetMainPort())
-			ins, err := parseDirs(srv, tmpIns)
+			ins, err := parseDirs(srv, tmpIns, sshTimeout)
 			if err != nil {
 				return "", nil, err
 			}
@@ -253,7 +253,7 @@ func parseInventory(dir string, inv *aini.InventoryData) (string, *meta.ClusterM
 			}
 
 			log.Debugf("Imported %s node %s:%d.", tmpIns.Role(), tmpIns.Host, tmpIns.GetMainPort())
-			ins, err := parseDirs(srv, tmpIns)
+			ins, err := parseDirs(srv, tmpIns, sshTimeout)
 			if err != nil {
 				return "", nil, err
 			}
@@ -302,7 +302,7 @@ func parseInventory(dir string, inv *aini.InventoryData) (string, *meta.ClusterM
 			}
 
 			log.Debugf("Imported %s node %s:%d.", tmpIns.Role(), tmpIns.Host, tmpIns.GetMainPort())
-			ins, err := parseDirs(srv, tmpIns)
+			ins, err := parseDirs(srv, tmpIns, sshTimeout)
 			if err != nil {
 				return "", nil, err
 			}
@@ -344,7 +344,7 @@ func parseInventory(dir string, inv *aini.InventoryData) (string, *meta.ClusterM
 			}
 
 			log.Debugf("Imported %s node %s:%d.", tmpIns.Role(), tmpIns.Host, tmpIns.GetMainPort())
-			ins, err := parseDirs(srv, tmpIns)
+			ins, err := parseDirs(srv, tmpIns, sshTimeout)
 			if err != nil {
 				return "", nil, err
 			}
@@ -382,7 +382,7 @@ func parseInventory(dir string, inv *aini.InventoryData) (string, *meta.ClusterM
 			}
 
 			log.Debugf("Imported %s node %s:%d.", tmpIns.Role(), tmpIns.Host, tmpIns.GetMainPort())
-			ins, err := parseDirs(srv, tmpIns)
+			ins, err := parseDirs(srv, tmpIns, sshTimeout)
 			if err != nil {
 				return "", nil, err
 			}
@@ -414,7 +414,7 @@ func parseInventory(dir string, inv *aini.InventoryData) (string, *meta.ClusterM
 			}
 
 			log.Debugf("Imported %s node %s:%d.", tmpIns.Role(), tmpIns.Host, tmpIns.GetMainPort())
-			ins, err := parseDirs(srv, tmpIns)
+			ins, err := parseDirs(srv, tmpIns, sshTimeout)
 			if err != nil {
 				return "", nil, err
 			}
@@ -461,7 +461,7 @@ func parseInventory(dir string, inv *aini.InventoryData) (string, *meta.ClusterM
 			}
 
 			log.Debugf("Imported %s node %s:%d.", tmpIns.Role(), tmpIns.Host, tmpIns.GetMainPort())
-			ins, err := parseDirs(srv, tmpIns)
+			ins, err := parseDirs(srv, tmpIns, sshTimeout)
 			if err != nil {
 				return "", nil, err
 			}
@@ -496,7 +496,7 @@ func parseInventory(dir string, inv *aini.InventoryData) (string, *meta.ClusterM
 			}
 
 			log.Debugf("Imported %s node %s:%d.", tmpIns.Role(), tmpIns.Host, tmpIns.GetMainPort())
-			ins, err := parseDirs(srv, tmpIns)
+			ins, err := parseDirs(srv, tmpIns, sshTimeout)
 			if err != nil {
 				return "", nil, err
 			}

--- a/pkg/api/pdapi.go
+++ b/pkg/api/pdapi.go
@@ -366,9 +366,8 @@ func (pc *PDClient) EvictStoreLeader(host string, retryOpt *utils.RetryOption) e
 				return nil
 			}
 			log.Debugf(
-				"Still waitting for %d/%d store leaders to transfer...",
+				"Still waitting for %d store leaders to transfer...",
 				currStoreInfo.Status.LeaderCount,
-				latestStore.Status.LeaderCount,
 			)
 		}
 

--- a/pkg/api/pdapi.go
+++ b/pkg/api/pdapi.go
@@ -346,9 +346,8 @@ func (pc *PDClient) EvictStoreLeader(host string, retryOpt *utils.RetryOption) e
 	// wait for the transfer to complete
 	if retryOpt == nil {
 		retryOpt = &utils.RetryOption{
-			Attempts: 120,
-			Delay:    time.Second * 5,
-			Timeout:  time.Second * 600,
+			Delay:   time.Second * 5,
+			Timeout: time.Second * 600,
 		}
 	}
 	if err := utils.Retry(func() error {
@@ -462,9 +461,8 @@ func (pc *PDClient) DelPD(name string, retryOpt *utils.RetryOption) error {
 	// wait for the deletion to complete
 	if retryOpt == nil {
 		retryOpt = &utils.RetryOption{
-			Attempts: 30,
-			Delay:    time.Second * 2,
-			Timeout:  time.Second * 60,
+			Delay:   time.Second * 2,
+			Timeout: time.Second * 60,
 		}
 	}
 	if err := utils.Retry(func() error {
@@ -551,9 +549,8 @@ func (pc *PDClient) DelStore(host string, retryOpt *utils.RetryOption) error {
 	// wait for the deletion to complete
 	if retryOpt == nil {
 		retryOpt = &utils.RetryOption{
-			Attempts: 30,
-			Delay:    time.Second * 2,
-			Timeout:  time.Second * 60,
+			Delay:   time.Second * 2,
+			Timeout: time.Second * 60,
 		}
 	}
 	if err := utils.Retry(func() error {

--- a/pkg/api/pdapi.go
+++ b/pkg/api/pdapi.go
@@ -159,19 +159,27 @@ func (pc *PDClient) GetStores() (*pdserverapi.StoresInfo, error) {
 }
 
 // WaitLeader wait until there's a leader or timeout.
-func (pc *PDClient) WaitLeader(timeout time.Duration) error {
-	start := time.Now()
-	for {
+func (pc *PDClient) WaitLeader(retryOpt *utils.RetryOption) error {
+	if retryOpt == nil {
+		retryOpt = &utils.RetryOption{
+			Delay:   time.Second * 1,
+			Timeout: time.Second * 30,
+		}
+	}
+
+	if err := utils.Retry(func() error {
 		_, err := pc.GetLeader()
 		if err == nil {
 			return nil
 		}
 
-		if time.Since(start) >= timeout {
-			return err
-		}
-		time.Sleep(time.Second)
+		// return error by default, to make the retry work
+		log.Debugf("Still waitting for the PD leader to be elected")
+		return errors.New("still waitting for the PD leader to be elected")
+	}, *retryOpt); err != nil {
+		return fmt.Errorf("error getting PD leader, %v", err)
 	}
+	return nil
 }
 
 // GetLeader queries the leader node of PD cluster
@@ -218,7 +226,7 @@ func (pc *PDClient) GetMembers() (*pdpb.GetMembersResponse, error) {
 }
 
 // EvictPDLeader evicts the PD leader
-func (pc *PDClient) EvictPDLeader() error {
+func (pc *PDClient) EvictPDLeader(retryOpt *utils.RetryOption) error {
 	// get current members
 	members, err := pc.GetMembers()
 	if err != nil {
@@ -247,10 +255,11 @@ func (pc *PDClient) EvictPDLeader() error {
 	}
 
 	// wait for the transfer to complete
-	retryOpt := utils.RetryOption{
-		Attempts: 60,
-		Delay:    time.Second * 5,
-		Timeout:  time.Second * 300,
+	if retryOpt == nil {
+		retryOpt = &utils.RetryOption{
+			Delay:   time.Second * 5,
+			Timeout: time.Second * 300,
+		}
 	}
 	if err := utils.Retry(func() error {
 		currLeader, err := pc.GetLeader()
@@ -266,7 +275,7 @@ func (pc *PDClient) EvictPDLeader() error {
 		// return error by default, to make the retry work
 		log.Debugf("Still waitting for the PD leader to transfer")
 		return errors.New("still waitting for the PD leader to transfer")
-	}, retryOpt); err != nil {
+	}, *retryOpt); err != nil {
 		return fmt.Errorf("error evicting PD leader, %v", err)
 	}
 	return nil
@@ -285,7 +294,7 @@ type pdSchedulerRequest struct {
 
 // EvictStoreLeader evicts the store leaders
 // The host parameter should be in format of IP:Port, that matches store's address
-func (pc *PDClient) EvictStoreLeader(host string) error {
+func (pc *PDClient) EvictStoreLeader(host string, retryOpt *utils.RetryOption) error {
 	// get info of current stores
 	stores, err := pc.GetStores()
 	if err != nil {
@@ -335,10 +344,12 @@ func (pc *PDClient) EvictStoreLeader(host string) error {
 	}
 
 	// wait for the transfer to complete
-	retryOpt := utils.RetryOption{
-		Attempts: 120,
-		Delay:    time.Second * 5,
-		Timeout:  time.Second * 600,
+	if retryOpt == nil {
+		retryOpt = &utils.RetryOption{
+			Attempts: 120,
+			Delay:    time.Second * 5,
+			Timeout:  time.Second * 600,
+		}
 	}
 	if err := utils.Retry(func() error {
 		currStores, err := pc.GetStores()
@@ -363,7 +374,7 @@ func (pc *PDClient) EvictStoreLeader(host string) error {
 
 		// return error by default, to make the retry work
 		return errors.New("still waitting for the store leaders to transfer")
-	}, retryOpt); err != nil {
+	}, *retryOpt); err != nil {
 		return fmt.Errorf("error evicting store leader from %s, %v", host, err)
 	}
 	return nil
@@ -427,7 +438,7 @@ func (pc *PDClient) RemoveStoreEvict(host string) error {
 }
 
 // DelPD deletes a PD node from the cluster, name is the Name of the PD member
-func (pc *PDClient) DelPD(name string) error {
+func (pc *PDClient) DelPD(name string, retryOpt *utils.RetryOption) error {
 	// get current members
 	members, err := pc.GetMembers()
 	if err != nil {
@@ -450,10 +461,12 @@ func (pc *PDClient) DelPD(name string) error {
 	}
 
 	// wait for the deletion to complete
-	retryOpt := utils.RetryOption{
-		Attempts: 30,
-		Delay:    time.Second * 2,
-		Timeout:  time.Second * 60,
+	if retryOpt == nil {
+		retryOpt = &utils.RetryOption{
+			Attempts: 30,
+			Delay:    time.Second * 2,
+			Timeout:  time.Second * 60,
+		}
 	}
 	if err := utils.Retry(func() error {
 		currMembers, err := pc.GetMembers()
@@ -469,7 +482,7 @@ func (pc *PDClient) DelPD(name string) error {
 		}
 
 		return nil
-	}, retryOpt); err != nil {
+	}, *retryOpt); err != nil {
 		return fmt.Errorf("error deleting PD node, %v", err)
 	}
 	return nil
@@ -506,7 +519,7 @@ var ErrStoreNotExists = errors.New("store not exists")
 
 // DelStore deletes stores from a (TiKV) host
 // The host parameter should be in format of IP:Port, that matches store's address
-func (pc *PDClient) DelStore(host string) error {
+func (pc *PDClient) DelStore(host string, retryOpt *utils.RetryOption) error {
 	// get info of current stores
 	stores, err := pc.GetStores()
 	if err != nil {
@@ -537,10 +550,12 @@ func (pc *PDClient) DelStore(host string) error {
 	}
 
 	// wait for the deletion to complete
-	retryOpt := utils.RetryOption{
-		Attempts: 30,
-		Delay:    time.Second * 2,
-		Timeout:  time.Second * 60,
+	if retryOpt == nil {
+		retryOpt = &utils.RetryOption{
+			Attempts: 30,
+			Delay:    time.Second * 2,
+			Timeout:  time.Second * 60,
+		}
 	}
 	if err := utils.Retry(func() error {
 		currStores, err := pc.GetStores()
@@ -563,7 +578,7 @@ func (pc *PDClient) DelStore(host string) error {
 		}
 
 		return nil
-	}, retryOpt); err != nil {
+	}, *retryOpt); err != nil {
 		return fmt.Errorf("error deleting store, %v", err)
 	}
 	return nil

--- a/pkg/executor/ssh.go
+++ b/pkg/executor/ssh.go
@@ -63,6 +63,8 @@ type (
 		Password   string // password of the user
 		KeyFile    string // path to the private key file
 		Passphrase string // passphrase of the private key file
+		// Timeout is the maximum amount of time for the TCP connection to establish.
+		Timeout time.Duration
 	}
 )
 
@@ -82,13 +84,16 @@ func (e *SSHExecutor) Initialize(config SSHConfig) {
 		config.Port = 22
 	}
 
+	if config.Timeout == 0 {
+		config.Timeout = time.Second * 5 // default timeout is 5 sec
+	}
+
 	// build easyssh config
 	e.Config = &easyssh.MakeConfig{
-		Server: config.Host,
-		Port:   strconv.Itoa(config.Port),
-		User:   config.User,
-		// Timeout is the maximum amount of time for the TCP connection to establish.
-		Timeout: time.Second * 5, // default timeout is 5 sec
+		Server:  config.Host,
+		Port:    strconv.Itoa(config.Port),
+		User:    config.User,
+		Timeout: config.Timeout, // timeout when connecting to remote
 	}
 
 	// prefer private key authentication

--- a/pkg/module/wait_for.go
+++ b/pkg/module/wait_for.go
@@ -86,7 +86,7 @@ func (w *WaitFor) Execute(e executor.TiOpsExecutor) (err error) {
 		return err
 	}, retryOpt); err != nil {
 		// TODO: add a debug log about the real err returned by utils.Retry()
-		return errors.Errorf("timed out waiting for port %d to be %s", w.c.Port, w.c.State)
+		return errors.Errorf("timed out waiting for port %d to be %s after %s", w.c.Port, w.c.State, w.c.Timeout)
 	}
 	return nil
 }

--- a/pkg/module/wait_for.go
+++ b/pkg/module/wait_for.go
@@ -64,9 +64,8 @@ func (w *WaitFor) Execute(e executor.TiOpsExecutor) (err error) {
 	pattern := []byte(fmt.Sprintf(":%d ", w.c.Port))
 
 	retryOpt := utils.RetryOption{
-		Attempts: 60,
-		Delay:    w.c.Sleep,
-		Timeout:  w.c.Timeout,
+		Delay:   w.c.Sleep,
+		Timeout: w.c.Timeout,
 	}
 	if err := utils.Retry(func() error {
 		// only listing TCP ports

--- a/pkg/operation/operation.go
+++ b/pkg/operation/operation.go
@@ -26,7 +26,7 @@ type Options struct {
 	Roles   []string
 	Nodes   []string
 	Force   bool  // Option for upgrade subcommand
-	Timeout int64 // timeout in seconds for operations that support it
+	Timeout int64 // timeout in seconds for operations that support it, not to confuse with SSH timeout
 }
 
 // Operation represents the type of cluster operation

--- a/pkg/operation/operation.go
+++ b/pkg/operation/operation.go
@@ -23,9 +23,10 @@ import (
 
 // Options represents the operation options
 type Options struct {
-	Roles []string
-	Nodes []string
-	Force bool // Option for upgrade subcommand
+	Roles   []string
+	Nodes   []string
+	Force   bool  // Option for upgrade subcommand
+	Timeout int64 // timeout in seconds for operations that support it
 }
 
 // Operation represents the type of cluster operation

--- a/pkg/operation/upgrade.go
+++ b/pkg/operation/upgrade.go
@@ -40,7 +40,7 @@ func Upgrade(
 
 	timeoutOpt := &utils.RetryOption{
 		Timeout: time.Second * time.Duration(options.Timeout),
-		Delay:   time.Second * 5,
+		Delay:   time.Second * 2,
 	}
 
 	for _, component := range components {

--- a/pkg/operation/upgrade.go
+++ b/pkg/operation/upgrade.go
@@ -20,11 +20,10 @@ import (
 	"github.com/pingcap-incubator/tiup-cluster/pkg/api"
 	"github.com/pingcap-incubator/tiup-cluster/pkg/log"
 	"github.com/pingcap-incubator/tiup-cluster/pkg/meta"
+	"github.com/pingcap-incubator/tiup-cluster/pkg/utils"
 	"github.com/pingcap-incubator/tiup/pkg/set"
 	"github.com/pingcap/errors"
 )
-
-var defaultWaitLeaderTimeout = time.Second * 30
 
 // Upgrade the cluster.
 func Upgrade(
@@ -38,6 +37,11 @@ func Upgrade(
 	components = filterComponent(components, roleFilter)
 
 	leaderAware := set.NewStringSet(meta.ComponentPD, meta.ComponentTiKV)
+
+	timeoutOpt := &utils.RetryOption{
+		Timeout: time.Second * time.Duration(options.Timeout),
+		Delay:   time.Second * 5,
+	}
 
 	for _, component := range components {
 		instances := filterInstance(component.Instances(), nodeFilter)
@@ -59,7 +63,7 @@ func Upgrade(
 					}
 
 					if len(spec.PDServers) > 1 && leader.Name == instance.(*meta.PDInstance).Name {
-						if err := pdClient.EvictPDLeader(); err != nil {
+						if err := pdClient.EvictPDLeader(timeoutOpt); err != nil {
 							return errors.Annotatef(err, "failed to evict PD leader %s", instance.GetHost())
 						}
 					}
@@ -78,13 +82,13 @@ func Upgrade(
 				// Make sure there's leader of PD.
 				// Although we evict pd leader when restart pd,
 				// But when there's only one PD instance the pd might not serve request right away after restart.
-				err := pdClient.WaitLeader(defaultWaitLeaderTimeout)
+				err := pdClient.WaitLeader(timeoutOpt)
 				if err != nil {
 					return errors.Annotate(err, "failed to wait leader")
 				}
 
 				for _, instance := range instances {
-					if err := pdClient.EvictStoreLeader(addr(instance)); err != nil {
+					if err := pdClient.EvictStoreLeader(addr(instance), timeoutOpt); err != nil {
 						return errors.Annotatef(err, "failed to evict store leader %s", instance.GetHost())
 					}
 

--- a/pkg/task/builder.go
+++ b/pkg/task/builder.go
@@ -30,7 +30,12 @@ func NewBuilder() *Builder {
 }
 
 // RootSSH appends a RootSSH task to the current task collection
-func (b *Builder) RootSSH(host string, port int, user, password, keyFile, passphrase string) *Builder {
+func (b *Builder) RootSSH(
+	host string,
+	port int,
+	user, password, keyFile, passphrase string,
+	sshTimeout int64,
+) *Builder {
 	b.tasks = append(b.tasks, &RootSSH{
 		host:       host,
 		port:       port,
@@ -38,15 +43,17 @@ func (b *Builder) RootSSH(host string, port int, user, password, keyFile, passph
 		password:   password,
 		keyFile:    keyFile,
 		passphrase: passphrase,
+		timeout:    sshTimeout,
 	})
 	return b
 }
 
 // UserSSH append a UserSSH task to the current task collection
-func (b *Builder) UserSSH(host, deployUser string) *Builder {
+func (b *Builder) UserSSH(host, deployUser string, sshTimeout int64) *Builder {
 	b.tasks = append(b.tasks, &UserSSH{
 		host:       host,
 		deployUser: deployUser,
+		timeout:    sshTimeout,
 	})
 	return b
 }
@@ -61,13 +68,14 @@ func (b *Builder) Func(name string, fn func() error) *Builder {
 }
 
 // ClusterSSH init all UserSSH need for the cluster.
-func (b *Builder) ClusterSSH(spec *meta.Specification, deployUser string) *Builder {
+func (b *Builder) ClusterSSH(spec *meta.Specification, deployUser string, sshTimeout int64) *Builder {
 	var tasks []Task
 	for _, com := range spec.ComponentsByStartOrder() {
 		for _, in := range com.Instances() {
 			tasks = append(tasks, &UserSSH{
 				host:       in.GetHost(),
 				deployUser: deployUser,
+				timeout:    sshTimeout,
 			})
 		}
 	}

--- a/pkg/task/context.go
+++ b/pkg/task/context.go
@@ -14,6 +14,8 @@
 package task
 
 import (
+	"time"
+
 	"github.com/pingcap-incubator/tiup-cluster/pkg/executor"
 	"github.com/pingcap-incubator/tiup-cluster/pkg/meta"
 	"github.com/pingcap/errors"
@@ -27,7 +29,7 @@ func (ctx *Context) SetSSHKeySet(privateKeyPath string, publicKeyPath string) er
 }
 
 // SetClusterSSH set cluster user ssh executor in context.
-func (ctx *Context) SetClusterSSH(topo *meta.Specification, deployUser string) error {
+func (ctx *Context) SetClusterSSH(topo *meta.Specification, deployUser string, sshTimeout int64) error {
 	if len(ctx.PrivateKeyPath) == 0 {
 		return errors.Errorf("context has no PrivateKeyPath")
 	}
@@ -38,6 +40,7 @@ func (ctx *Context) SetClusterSSH(topo *meta.Specification, deployUser string) e
 				Host:    in.GetHost(),
 				KeyFile: ctx.PrivateKeyPath,
 				User:    deployUser,
+				Timeout: time.Second * time.Duration(sshTimeout),
 			}
 
 			e := executor.NewSSHExecutor(cf)

--- a/pkg/task/ssh.go
+++ b/pkg/task/ssh.go
@@ -15,6 +15,7 @@ package task
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/joomcode/errorx"
 	"github.com/pingcap-incubator/tiup-cluster/pkg/executor"
@@ -32,6 +33,7 @@ type RootSSH struct {
 	password   string // password of the user
 	keyFile    string // path to the private key file
 	passphrase string // passphrase of the private key file
+	timeout    int64  // timeout in seconds when connecting via SSH
 }
 
 // Execute implements the Task interface
@@ -43,6 +45,7 @@ func (s *RootSSH) Execute(ctx *Context) error {
 		Password:   s.password,
 		KeyFile:    s.keyFile,
 		Passphrase: s.passphrase,
+		Timeout:    time.Second * time.Duration(s.timeout),
 	})
 
 	ctx.SetExecutor(s.host, e)
@@ -69,6 +72,7 @@ func (s RootSSH) String() string {
 type UserSSH struct {
 	host       string
 	deployUser string
+	timeout    int64
 }
 
 // Execute implements the Task interface
@@ -77,6 +81,7 @@ func (s *UserSSH) Execute(ctx *Context) error {
 		Host:    s.host,
 		KeyFile: ctx.PrivateKeyPath,
 		User:    s.deployUser,
+		Timeout: time.Second * time.Duration(s.timeout),
 	})
 
 	ctx.SetExecutor(s.host, e)

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -38,16 +38,16 @@ func JoinInt(nums []int, delim string) string {
 
 // RetryOption is options for Retry()
 type RetryOption struct {
-	Attempts int
+	Attempts int64
 	Delay    time.Duration
 	Timeout  time.Duration
 }
 
 // default values for RetryOption
 var (
-	defaultAttempts = 10
-	defaultDelay    = time.Millisecond * 500 // 500ms
-	defaultTimeout  = time.Second * 10       // 10s
+	defaultAttempts int64 = 10
+	defaultDelay          = time.Millisecond * 500 // 500ms
+	defaultTimeout        = time.Second * 10       // 10s
 )
 
 // Retry retries the func until it returns no error or reaches attempts limit or
@@ -64,15 +64,19 @@ func Retry(doFunc func() error, opts ...RetryOption) error {
 		}
 	}
 
-	// attempts must be greater than 0
+	// options must be greater than 0
+	if cfg.Delay <= 0 || cfg.Timeout <= 0 {
+		return fmt.Errorf("delay (%ds) and timeout (%s) must be greater than 0", cfg.Delay, cfg.Timeout)
+	}
+	// set attempts automatically for invalid value
 	if cfg.Attempts <= 0 {
-		cfg.Attempts = defaultAttempts
+		cfg.Attempts = cfg.Timeout.Milliseconds()/cfg.Delay.Milliseconds() + 1
 	}
 
 	timeoutChan := time.After(cfg.Timeout)
 
 	// call the function
-	var attemptCount int
+	var attemptCount int64
 	for attemptCount = 0; attemptCount < cfg.Attempts; attemptCount++ {
 		if err := doFunc(); err == nil {
 			return nil

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -64,11 +64,14 @@ func Retry(doFunc func() error, opts ...RetryOption) error {
 		}
 	}
 
-	// options must be greater than 0
-	if cfg.Delay <= 0 || cfg.Timeout <= 0 {
-		return fmt.Errorf("delay (%ds) and timeout (%s) must be greater than 0", cfg.Delay, cfg.Timeout)
+	// timeout must be greater than 0
+	if cfg.Timeout <= 0 {
+		return fmt.Errorf("timeout (%s) must be greater than 0", cfg.Timeout)
 	}
-	// set attempts automatically for invalid value
+	// set options automatically for invalid value
+	if cfg.Delay <= 0 {
+		cfg.Delay = defaultDelay
+	}
 	if cfg.Attempts <= 0 {
 		cfg.Attempts = cfg.Timeout.Milliseconds()/cfg.Delay.Milliseconds() + 1
 	}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -15,7 +15,6 @@ package utils
 
 import (
 	"fmt"
-	"reflect"
 	"strconv"
 	"strings"
 	"time"
@@ -35,22 +34,6 @@ func JoinInt(nums []int, delim string) string {
 		result += delim
 	}
 	return strings.TrimSuffix(result, delim)
-}
-
-// InSlice checks if a element is present in a slice, returns false if slice is
-// empty, or any other error occurs
-func InSlice(elem interface{}, slice interface{}) bool {
-	s := reflect.ValueOf(slice)
-	if s.Kind() != reflect.Slice {
-		return false
-	}
-
-	for i := 0; i < s.Len(); i++ {
-		if elem == s.Index(i).Interface() {
-			return true
-		}
-	}
-	return false
 }
 
 // RetryOption is options for Retry()


### PR DESCRIPTION
 - Add `--transfer-timeout` argument to set custom timeout when transferring leaders (Close #189 )
 - Add `--ssh-timeout` argument to set custom timeout when connecting to SSH servers