### PR TITLE
import: merge imported config of instances

### DIFF
--- a/pkg/meta/logic.go
+++ b/pkg/meta/logic.go
@@ -167,7 +167,7 @@ func (i *instance) mergeServerConfig(e executor.TiOpsExecutor, globalConf, insta
 	return e.Transfer(fp, dst, false)
 }
 
-// mergeServerConfig merges the server configuration and overwrite the global configuration
+// mergeTiFlashLearnerServerConfig merges the server configuration and overwrite the global configuration
 func (i *instance) mergeTiFlashLearnerServerConfig(e executor.TiOpsExecutor, globalConf, instanceConf map[string]interface{}, paths DirPaths) error {
 	fp := filepath.Join(paths.Cache, fmt.Sprintf("%s-learner-%s-%d.toml", i.ComponentName(), i.GetHost(), i.GetPort()))
 	conf, err := merge2Toml(i.ComponentName()+"-learner", globalConf, instanceConf)
@@ -335,7 +335,24 @@ func (i *TiDBInstance) InitConfig(e executor.TiOpsExecutor, clusterName, cluster
 	if _, _, err := e.Execute("chmod +x "+dst, false); err != nil {
 		return err
 	}
-	return i.mergeServerConfig(e, i.topo.ServerConfigs.TiDB, spec.Config, paths)
+
+	specConfig := spec.Config
+	// merge config files for imported instance
+	if i.IsImported() {
+		mergedConfig, err := mergeImported(
+			clusterName,
+			i.ComponentName(),
+			i.GetHost(),
+			i.GetPort(),
+			spec.Config,
+		)
+		if err != nil {
+			return err
+		}
+		specConfig = mergedConfig
+	}
+
+	return i.mergeServerConfig(e, i.topo.ServerConfigs.TiDB, specConfig, paths)
 }
 
 // ScaleConfig deploy temporary config on scaling
@@ -415,7 +432,23 @@ func (i *TiKVInstance) InitConfig(e executor.TiOpsExecutor, clusterName, cluster
 		return err
 	}
 
-	return i.mergeServerConfig(e, i.topo.ServerConfigs.TiKV, spec.Config, paths)
+	specConfig := spec.Config
+	// merge config files for imported instance
+	if i.IsImported() {
+		mergedConfig, err := mergeImported(
+			clusterName,
+			i.ComponentName(),
+			i.GetHost(),
+			i.GetPort(),
+			spec.Config,
+		)
+		if err != nil {
+			return err
+		}
+		specConfig = mergedConfig
+	}
+
+	return i.mergeServerConfig(e, i.topo.ServerConfigs.TiKV, specConfig, paths)
 }
 
 // ScaleConfig deploy temporary config on scaling
@@ -515,7 +548,23 @@ func (i *PDInstance) InitConfig(e executor.TiOpsExecutor, clusterName, clusterVe
 		spec.Config["pd-server.metric-storage"] = fmt.Sprintf("http://%s:%d", prom.Host, prom.Port)
 	}
 
-	return i.mergeServerConfig(e, i.topo.ServerConfigs.PD, spec.Config, paths)
+	specConfig := spec.Config
+	// merge config files for imported instance
+	if i.IsImported() {
+		mergedConfig, err := mergeImported(
+			clusterName,
+			i.ComponentName(),
+			i.GetHost(),
+			i.GetPort(),
+			spec.Config,
+		)
+		if err != nil {
+			return err
+		}
+		specConfig = mergedConfig
+	}
+
+	return i.mergeServerConfig(e, i.topo.ServerConfigs.PD, specConfig, paths)
 }
 
 // ScaleConfig deploy temporary config on scaling
@@ -750,7 +799,23 @@ func (i *TiFlashInstance) InitConfig(e executor.TiOpsExecutor, clusterName, clus
 		return err
 	}
 
-	return i.mergeServerConfig(e, conf, spec.Config, paths)
+	specConfig := spec.Config
+	// merge config files for imported instance
+	if i.IsImported() {
+		mergedConfig, err := mergeImported(
+			clusterName,
+			i.ComponentName(),
+			i.GetHost(),
+			i.GetPort(),
+			spec.Config,
+		)
+		if err != nil {
+			return err
+		}
+		specConfig = mergedConfig
+	}
+
+	return i.mergeServerConfig(e, conf, specConfig, paths)
 }
 
 // ScaleConfig deploy temporary config on scaling

--- a/pkg/meta/logic.go
+++ b/pkg/meta/logic.go
@@ -339,13 +339,21 @@ func (i *TiDBInstance) InitConfig(e executor.TiOpsExecutor, clusterName, cluster
 	specConfig := spec.Config
 	// merge config files for imported instance
 	if i.IsImported() {
-		mergedConfig, err := mergeImported(
+		configPath := ClusterPath(
 			clusterName,
-			i.ComponentName(),
-			i.GetHost(),
-			i.GetPort(),
-			spec.Config,
+			"config",
+			fmt.Sprintf(
+				"%s-%s-%d.toml",
+				i.ComponentName(),
+				i.GetHost(),
+				i.GetPort(),
+			),
 		)
+		importConfig, err := ioutil.ReadFile(configPath)
+		if err != nil {
+			return err
+		}
+		mergedConfig, err := mergeImported(importConfig, spec.Config)
 		if err != nil {
 			return err
 		}
@@ -435,13 +443,21 @@ func (i *TiKVInstance) InitConfig(e executor.TiOpsExecutor, clusterName, cluster
 	specConfig := spec.Config
 	// merge config files for imported instance
 	if i.IsImported() {
-		mergedConfig, err := mergeImported(
+		configPath := ClusterPath(
 			clusterName,
-			i.ComponentName(),
-			i.GetHost(),
-			i.GetPort(),
-			spec.Config,
+			"config",
+			fmt.Sprintf(
+				"%s-%s-%d.toml",
+				i.ComponentName(),
+				i.GetHost(),
+				i.GetPort(),
+			),
 		)
+		importConfig, err := ioutil.ReadFile(configPath)
+		if err != nil {
+			return err
+		}
+		mergedConfig, err := mergeImported(importConfig, spec.Config)
 		if err != nil {
 			return err
 		}
@@ -551,13 +567,21 @@ func (i *PDInstance) InitConfig(e executor.TiOpsExecutor, clusterName, clusterVe
 	specConfig := spec.Config
 	// merge config files for imported instance
 	if i.IsImported() {
-		mergedConfig, err := mergeImported(
+		configPath := ClusterPath(
 			clusterName,
-			i.ComponentName(),
-			i.GetHost(),
-			i.GetPort(),
-			spec.Config,
+			"config",
+			fmt.Sprintf(
+				"%s-%s-%d.toml",
+				i.ComponentName(),
+				i.GetHost(),
+				i.GetPort(),
+			),
 		)
+		importConfig, err := ioutil.ReadFile(configPath)
+		if err != nil {
+			return err
+		}
+		mergedConfig, err := mergeImported(importConfig, spec.Config)
 		if err != nil {
 			return err
 		}
@@ -792,13 +816,21 @@ func (i *TiFlashInstance) InitConfig(e executor.TiOpsExecutor, clusterName, clus
 	specLernerConfig := spec.LearnerConfig
 	// merge config files for imported instance
 	if i.IsImported() {
-		mergedConfig, err := mergeImported(
+		configPath := ClusterPath(
 			clusterName,
-			i.ComponentName()+"-learner",
-			i.GetHost(),
-			i.GetPort(),
-			spec.LearnerConfig,
+			"config",
+			fmt.Sprintf(
+				"%s-%s-%d.toml",
+				i.ComponentName()+"learner",
+				i.GetHost(),
+				i.GetPort(),
+			),
 		)
+		importConfig, err := ioutil.ReadFile(configPath)
+		if err != nil {
+			return err
+		}
+		mergedConfig, err := mergeImported(importConfig, spec.LearnerConfig)
 		if err != nil {
 			return err
 		}
@@ -818,13 +850,21 @@ func (i *TiFlashInstance) InitConfig(e executor.TiOpsExecutor, clusterName, clus
 	specConfig := spec.Config
 	// merge config files for imported instance
 	if i.IsImported() {
-		specConfig, err = mergeImported(
+		configPath := ClusterPath(
 			clusterName,
-			i.ComponentName(),
-			i.GetHost(),
-			i.GetPort(),
-			spec.Config,
+			"config",
+			fmt.Sprintf(
+				"%s-%s-%d.toml",
+				i.ComponentName(),
+				i.GetHost(),
+				i.GetPort(),
+			),
 		)
+		importConfig, err := ioutil.ReadFile(configPath)
+		if err != nil {
+			return err
+		}
+		specConfig, err = mergeImported(importConfig, spec.Config)
 		if err != nil {
 			return err
 		}

--- a/pkg/meta/logic.go
+++ b/pkg/meta/logic.go
@@ -789,7 +789,23 @@ func (i *TiFlashInstance) InitConfig(e executor.TiOpsExecutor, clusterName, clus
 		return err
 	}
 
-	err = i.mergeTiFlashLearnerServerConfig(e, confLearner, spec.LearnerConfig, paths)
+	specLernerConfig := spec.LearnerConfig
+	// merge config files for imported instance
+	if i.IsImported() {
+		mergedConfig, err := mergeImported(
+			clusterName,
+			i.ComponentName()+"-learner",
+			i.GetHost(),
+			i.GetPort(),
+			spec.LearnerConfig,
+		)
+		if err != nil {
+			return err
+		}
+		specLernerConfig = mergedConfig
+	}
+
+	err = i.mergeTiFlashLearnerServerConfig(e, confLearner, specLernerConfig, paths)
 	if err != nil {
 		return err
 	}
@@ -802,7 +818,7 @@ func (i *TiFlashInstance) InitConfig(e executor.TiOpsExecutor, clusterName, clus
 	specConfig := spec.Config
 	// merge config files for imported instance
 	if i.IsImported() {
-		mergedConfig, err := mergeImported(
+		specConfig, err = mergeImported(
 			clusterName,
 			i.ComponentName(),
 			i.GetHost(),
@@ -812,7 +828,6 @@ func (i *TiFlashInstance) InitConfig(e executor.TiOpsExecutor, clusterName, clus
 		if err != nil {
 			return err
 		}
-		specConfig = mergedConfig
 	}
 
 	return i.mergeServerConfig(e, conf, specConfig, paths)

--- a/pkg/meta/server_config.go
+++ b/pkg/meta/server_config.go
@@ -16,7 +16,6 @@ package meta
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"reflect"
 	"strings"
 
@@ -128,23 +127,9 @@ func merge2Toml(comp string, global, overwrite map[string]interface{}) ([]byte, 
 	return buf.Bytes(), nil
 }
 
-func mergeImported(
-	clusterName, comp, host string,
-	port int,
-	specConfig map[string]interface{},
-) (map[string]interface{}, error) {
-	// read imported config of the instance
-	configPath := ClusterPath(
-		clusterName,
-		"config",
-		fmt.Sprintf("%s-%s-%d.toml", comp, host, port),
-	)
-	raw, err := ioutil.ReadFile(configPath)
-	if err != nil {
-		return specConfig, err
-	}
+func mergeImported(importConfig []byte, specConfig map[string]interface{}) (map[string]interface{}, error) {
 	var configData map[string]interface{}
-	if err := toml.Unmarshal(raw, &configData); err != nil {
+	if err := toml.Unmarshal(importConfig, &configData); err != nil {
 		return specConfig, err
 	}
 

--- a/pkg/meta/topology_test.go
+++ b/pkg/meta/topology_test.go
@@ -385,3 +385,71 @@ split-merge-interval = "1h"
 	c.Assert(err, IsNil)
 	c.Assert(string(got), DeepEquals, expected)
 }
+
+func (s *metaSuite) TestMergeImported(c *C) {
+	spec := TopologySpecification{}
+
+	// values set in topology specification of the cluster
+	err := yaml.Unmarshal([]byte(`
+server_configs:
+  tikv:
+    config.item1: 100
+    config.item2: 300
+    config.item3.item5: 500
+    config.item3.item6: 600
+    config2.item4.item7: 700
+
+tikv_servers:
+  - host: 172.16.5.138
+    config:
+      config.item2: 500
+      config.item3.item5: 700
+      config2.itemy: 1000
+
+`), &spec)
+	c.Assert(err, IsNil)
+
+	// values set in imported configs, this will be overritten by values from
+	// topology specification if present there
+	config := []byte(`
+[config]
+item2 = 501
+[config.item3]
+item5 = 701
+item6 = 600
+
+[config2]
+itemx = "valuex"
+itemy = 999
+[config2.item4]
+item7 = 780
+`)
+
+	expected := `# WARNING: This file was auto-generated. Do not edit! All your edit might be overwritten!
+# You can use 'tiup cluster edit-config' and 'tiup cluster reload' to update the configuration
+# All configuration items you want to change can be added to:
+# server_configs:
+#   tikv:
+#     aa.b1.c3: value
+#     aa.b2.c4: value
+[config]
+item1 = 100
+item2 = 500
+[config.item3]
+item5 = 700
+item6 = 600
+
+[config2]
+itemx = "valuex"
+itemy = 1000
+[config2.item4]
+item7 = 780
+`
+
+	merge1, err := mergeImported(config, spec.TiKVServers[0].Config)
+	c.Assert(err, IsNil)
+
+	merge2, err := merge2Toml(ComponentTiKV, spec.ServerConfigs.TiKV, merge1)
+	c.Assert(err, IsNil)
+	c.Assert(string(merge2), DeepEquals, expected)
+}


### PR DESCRIPTION
Close: #216 

Note that this only work for `upgrade`, if scaling out a new instance, all configuration come from the topology file (global configs set during deploying the cluster)