### PR TITLE
Support integration test

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -1,0 +1,79 @@
+---
+
+name: integrate
+
+on:
+  pull_request:
+    branches:
+      - master
+      - release-*
+
+
+jobs:
+
+  test_all:
+    runs-on: ubuntu-latest
+    env:
+      working-directory: ${{ github.workspace   }}/go/src/github.com/${{ github.repository   }}
+    steps:
+      - name: Set up Go 1.13
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.13
+        id: go
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha  }}
+          path: go/src/github.com/${{ github.repository  }}
+
+      - name: Build the docker-compose stack
+        working-directory: ${{env.working-directory}}
+        # with --dev the first run will fail for unknow reason, just retry it and will success now..
+        run: TIUP_CLUSTER_ROOT=${{env.working-directory}} ./docker/up.sh --daemon --dev || TIUP_CLUSTER_ROOT=${{env.working-directory}} ./docker/up.sh --daemon --dev
+
+      - name: Check running containers
+        run: |
+          docker ps
+          df -h
+          free -h
+
+      - name: Run test suite
+        id: test
+        working-directory: ${{env.working-directory}}
+        run: |
+          # should not use -it
+          # ref: https://stackoverflow.com/questions/43099116/error-the-input-device-is-not-a-tty
+          docker exec  tiup-cluster-control bash /tiup-cluster/tests/run.sh
+
+      - name: Collect component log
+        working-directory: ${{env.working-directory}}
+        # if: steps.test.outputs.exit_code != 0
+        if: always()
+        run: |
+          docker exec  tiup-cluster-control bash /tiup-cluster/tests/script/pull_log.sh /tiup-cluster/logs
+          ls ${{env.working-directory}}
+          tar czvf ${{env.working-directory}}/logs.tar.gz ${{env.working-directory}}/logs/
+
+      - name: Upload component log
+        # if: steps.test.outputs.exit_code != 0
+        if: always()
+        uses: actions/upload-artifact@v1
+        with:
+          name: component_logs
+          path: ${{env.working-directory}}/logs.tar.gz
+
+      - name: Output cluster debug log
+        working-directory: ${{env.working-directory}}
+        if: always()
+        run: |
+          pwd
+          docker ps
+          df -h
+          free -h
+          "cat ./tests/*.log" || true
+
+      # - name: Setup tmate session
+      #   if: always()
+      #   uses: mxschmitt/action-tmate@v2

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ test: failpoint-enable unit-test #integration_test
 	@$(FAILPOINT_DISABLE)
 
 check-static: tools/bin/golangci-lint
-	tools/bin/golangci-lint run ./...
+	tools/bin/golangci-lint run --timeout 5m ./...
 
 coverage:
 	GO111MODULE=off go get github.com/wadey/gocovmerge

--- a/docker/up.sh
+++ b/docker/up.sh
@@ -148,7 +148,7 @@ INFO "Running \`docker-compose build\`"
 # shellcheck disable=SC2086
 docker-compose -f docker-compose.yml ${COMPOSE} ${DEV} build
 
-docker network create --gateway 172.19.0.1 --subnet 172.19.0.0/16 tiup-cluster > /dev/null 2>&1 || echo "Skip create tiup-cluster network"
+docker network create --gateway 172.19.0.1 --subnet 172.19.0.0/16 tiops > /dev/null 2>&1 || echo "Skip create tiup-cluster network"
 
 INFO "Running \`docker-compose up\`"
 if [ "${RUN_AS_DAEMON}" -eq 1 ]; then

--- a/pkg/cliutil/progress/progress.go
+++ b/pkg/cliutil/progress/progress.go
@@ -14,6 +14,8 @@
 package progress
 
 import (
+	"fmt"
+	"os"
 	"time"
 
 	"github.com/fatih/color"
@@ -29,11 +31,24 @@ var (
 	colorSpinner = color.New(color.FgHiCyan)
 )
 
+var refreshRate = time.Millisecond * 50
+
 const (
-	refreshRate = time.Millisecond * 50
-	doneTail    = "Done"
-	errorTail   = "Error"
+	doneTail  = "Done"
+	errorTail = "Error"
 )
+
+func init() {
+	v := os.Getenv("TIUP_CLUSTER_PROGRESS_REFRESH_RATE")
+	if v != "" {
+		d, err := time.ParseDuration(v)
+		if err != nil {
+			fmt.Println("ignore invalid refresh rate: ", v)
+			return
+		}
+		refreshRate = d
+	}
+}
 
 // Bar controls how a bar is displayed, for both single bar or multi bar item.
 type Bar interface {

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -6,6 +6,10 @@ set -eu
 # https://stackoverflow.com/a/246128/3858681
 pushd "$( cd "$( dirname "${BASH_SOURCE[0]}"  )" >/dev/null 2>&1 && pwd  )"
 
+PATH=$PATH:/tiup-cluster/bin
+export TIUP_CLUSTER_PROGRESS_REFRESH_RATE=10s
+export TIUP_CLUSTER_EXECUTE_DEFAULT_TIMEOUT=300s
+
 . ./script/util.sh
 
 # TODO remove this once embed the files in binary

--- a/tests/script/pull_log.sh
+++ b/tests/script/pull_log.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+
+out_dir=$1
+
+mkdir -p $out_dir
+
+hosts="172.19.0.101 172.19.0.102 172.19.0.103 172.19.0.104 172.19.0.105"
+
+for h in $hosts
+do
+	echo $h
+	mkdir $out_dir/$h
+
+	logs=$(ssh -o "StrictHostKeyChecking no" root@$h "find /home/tidb | grep '.*log/.*\.log'")
+
+	for log in $logs
+	do
+		scp -o "StrictHostKeyChecking no" -r root@$h:$log "$out_dir/$h/"
+	done
+done
+
+
+
+
+
+

--- a/tests/test_cmd.sh
+++ b/tests/test_cmd.sh
@@ -9,35 +9,37 @@ topo=./topo/full.yaml
 
 yes | tiup-cluster deploy $name $version $topo -i ~/.ssh/id_rsa
 
-yes | tiup-cluster stop $name
-
 yes | tiup-cluster start $name
+
+yes | tiup-cluster stop $name
 
 yes | tiup-cluster restart $name
 
 tiup-cluster display $name
 
+totol_sub_one=16
+
 echo "start scale in tidb"
 yes | tiup-cluster scale-in $name -N 172.19.0.101:4000
-wait_instance_num_reach $name 18
+wait_instance_num_reach $name $totol_sub_one
 echo "start scale out tidb"
 yes | tiup-cluster scale-out $name ./topo/full_scale_in_tidb.yaml
 
 echo "start scale in tikv"
 yes | tiup-cluster scale-in $name -N 172.19.0.103:20160
-wait_instance_num_reach $name 18
+wait_instance_num_reach $name $totol_sub_one
 echo "start scale out tikv"
 yes | tiup-cluster scale-out $name ./topo/full_scale_in_tikv.yaml
 
 echo "start scale in pd"
 yes | tiup-cluster scale-in $name -N 172.19.0.103:2379
-wait_instance_num_reach $name 18
+wait_instance_num_reach $name $totol_sub_one
 echo "start scale out pd"
 yes | tiup-cluster scale-out $name ./topo/full_scale_in_pd.yaml
 
 echo "start scale in pump"
 yes | tiup-cluster scale-in $name -N 172.19.0.103:8250
-wait_instance_num_reach $name 18
+wait_instance_num_reach $name $totol_sub_one
 echo "start scale out pump"
 yes | tiup-cluster scale-out $name ./topo/full_scale_in_pump.yaml
 

--- a/tests/topo/full.yaml
+++ b/tests/topo/full.yaml
@@ -2,8 +2,12 @@ server_configs:
     tidb:
         binlog.enable: true
         binlog.ignore-error: false
+    tikv:
+        storage.reserve-space: 1K
     pd:
         replication.enable-placement-rules: true
+    pump:
+        storage.stop-write-at-available-space: 1 mib
 
 tidb_servers:
   - host: 172.19.0.101
@@ -22,10 +26,12 @@ tikv_servers:
   - host: 172.19.0.104
   - host: 172.19.0.105
 
+# tiflash eat too much memory
+# and binary is more than 1G..
 tiflash_servers:
   - host: 172.19.0.103
-  - host: 172.19.0.104
-  - host: 172.19.0.105
+#   - host: 172.19.0.104
+#   - host: 172.19.0.105
 
 
 pump_servers:


### PR DESCRIPTION
- Add an integration test workflow to run the test 
- Fix network name create in `docker/up.sh` (we still use the name tiops in docker-compose file)
- Support change refresh rate of progress by env var
- Support change default execute timeout of the executor by env var
- Add a script `pull_log.sh` to pull logs of components(useful when the test fail in CI)
- Some minor updates of full.yaml to reduce the space need for the test.


note the runner of actions only has 2c/7g/14G, so we can not use too many resources in the test.
currently, it needs about 20m to run the test and is trigger by the pull request.

we can change to run daily if need.
