### PR TITLE
import: handle ansible_port in inventory properly

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,4 +33,5 @@ require (
 	golang.org/x/mod v0.2.0
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
 	golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd
+	gopkg.in/yaml.v2 v2.2.8
 )

--- a/pkg/ansible/inventory.go
+++ b/pkg/ansible/inventory.go
@@ -19,12 +19,12 @@ import (
 	"path/filepath"
 	"strconv"
 
-	"github.com/goccy/go-yaml"
 	"github.com/pingcap-incubator/tiup-cluster/pkg/cliutil"
 	"github.com/pingcap-incubator/tiup-cluster/pkg/log"
 	"github.com/pingcap-incubator/tiup-cluster/pkg/meta"
 	tiuputils "github.com/pingcap-incubator/tiup/pkg/utils"
 	"github.com/relex/aini"
+	"gopkg.in/yaml.v2"
 )
 
 var (
@@ -132,7 +132,7 @@ func parseInventory(dir string, inv *aini.InventoryData, sshTimeout int64) (stri
 			}
 			tmpIns := meta.TiDBSpec{
 				Host:     host,
-				SSHPort:  srv.Port,
+				SSHPort:  getHostPort(srv),
 				Imported: true,
 			}
 
@@ -178,7 +178,7 @@ func parseInventory(dir string, inv *aini.InventoryData, sshTimeout int64) (stri
 			}
 			tmpIns := meta.TiKVSpec{
 				Host:     host,
-				SSHPort:  srv.Port,
+				SSHPort:  getHostPort(srv),
 				Imported: true,
 			}
 
@@ -227,7 +227,7 @@ func parseInventory(dir string, inv *aini.InventoryData, sshTimeout int64) (stri
 			}
 			tmpIns := meta.PDSpec{
 				Host:     host,
-				SSHPort:  srv.Port,
+				SSHPort:  getHostPort(srv),
 				Imported: true,
 			}
 
@@ -276,7 +276,7 @@ func parseInventory(dir string, inv *aini.InventoryData, sshTimeout int64) (stri
 			}
 			tmpIns := meta.TiFlashSpec{
 				Host:     host,
-				SSHPort:  srv.Port,
+				SSHPort:  getHostPort(srv),
 				Imported: true,
 			}
 
@@ -330,7 +330,7 @@ func parseInventory(dir string, inv *aini.InventoryData, sshTimeout int64) (stri
 			}
 			tmpIns := meta.PrometheusSpec{
 				Host:     host,
-				SSHPort:  srv.Port,
+				SSHPort:  getHostPort(srv),
 				Imported: true,
 			}
 
@@ -379,7 +379,7 @@ func parseInventory(dir string, inv *aini.InventoryData, sshTimeout int64) (stri
 			}
 			tmpIns := meta.AlertManagerSpec{
 				Host:     host,
-				SSHPort:  srv.Port,
+				SSHPort:  getHostPort(srv),
 				Imported: true,
 			}
 
@@ -422,7 +422,7 @@ func parseInventory(dir string, inv *aini.InventoryData, sshTimeout int64) (stri
 			}
 			tmpIns := meta.GrafanaSpec{
 				Host:     host,
-				SSHPort:  srv.Port,
+				SSHPort:  getHostPort(srv),
 				Imported: true,
 			}
 
@@ -463,7 +463,7 @@ func parseInventory(dir string, inv *aini.InventoryData, sshTimeout int64) (stri
 			}
 			tmpIns := meta.PumpSpec{
 				Host:     host,
-				SSHPort:  srv.Port,
+				SSHPort:  getHostPort(srv),
 				Imported: true,
 			}
 
@@ -508,7 +508,7 @@ func parseInventory(dir string, inv *aini.InventoryData, sshTimeout int64) (stri
 			}
 			tmpIns := meta.DrainerSpec{
 				Host:     host,
-				SSHPort:  srv.Port,
+				SSHPort:  getHostPort(srv),
 				Imported: true,
 			}
 
@@ -549,4 +549,17 @@ func readGroupVars(dir, filename string) (map[string]string, error) {
 		return nil, err
 	}
 	return result, nil
+}
+
+// getHostPort tries to read the SSH port of the host
+func getHostPort(srv *aini.Host) int {
+	// aini parse the port inline with hostnames (e.g., something like `host:22`)
+	// but not handling the "ansible_port" variable
+	if port, ok := srv.Vars["ansible_port"]; ok {
+		intPort, err := strconv.Atoi(port)
+		if err == nil {
+			return intPort
+		} // else just return the srv.Port
+	}
+	return srv.Port
 }


### PR DESCRIPTION
The `aini` parses inline port of host in a format like `host:port`, but not handling the `ansible_port` variable. This PR add the support of customized SSH port set by `ansible_port` in inventory file.

Also, the `goccy/go-yaml` lib has sightly different behavior with `gopkg.in/yaml.v2`. When the value of a key is completely empty, `goccy/go-yaml` unmarshals all tailing contents of the file as the value of that key.

e.g., a file like this:
```
key1:
key2: value2
```
will end up being: `map[key1:map[key2: value2]]`, rather than `map[key1:"", key2: value2]`.

As we have several config templates using this kind of empty values in `tidb-ansible`, I'll keep using `gopkg.in/yaml.v2` for importing, until we have a better solution.