### PR TITLE
set madvdontneed=1 to shrink RSS after GC

### DIFF
--- a/templates/scripts/run_tidb.sh.tpl
+++ b/templates/scripts/run_tidb.sh.tpl
@@ -18,9 +18,9 @@ cd "${DEPLOY_DIR}" || exit 1
 {{- end}}
 
 {{- if .NumaNode}}
-exec numactl --cpunodebind={{.NumaNode}} --membind={{.NumaNode}} bin/tidb-server \
+exec numactl --cpunodebind={{.NumaNode}} --membind={{.NumaNode}} env GODEBUG=madvdontneed=1 bin/tidb-server \
 {{- else}}
-exec bin/tidb-server \
+exec env GODEBUG=madvdontneed=1 bin/tidb-server \
 {{- end}}
     -P {{.Port}} \
     --status="{{.StatusPort}}" \


### PR DESCRIPTION
Go 1.13 use `MADV_FREE` which will cause RSS don't shrink even if heap size is shrunk.

Set `madvdontneed=1` in `GODEBUG` will ask runtime use `MADV_DONTNEED`, which will shrink RSS size more quickly.