### PR TITLE
log: fix wrong permission

### DIFF
--- a/pkg/logger/debug.go
+++ b/pkg/logger/debug.go
@@ -48,7 +48,7 @@ func OutputDebugLog() {
 		filePath = fileName
 	}
 
-	err = ioutil.WriteFile(filePath, debugBuffer.Bytes(), os.ModePerm)
+	err = ioutil.WriteFile(filePath, debugBuffer.Bytes(), 0644)
 	if err != nil {
 		_, _ = colorutil.ColorWarningMsg.Fprint(os.Stderr, "\nWarn: Failed to write error debug log.\n")
 	} else {


### PR DESCRIPTION
log file should be plain text and not executable.