### PR TITLE
cmd/exec: print output of command

### DIFF
--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -14,8 +14,6 @@
 package cmd
 
 import (
-	"sort"
-
 	"github.com/fatih/color"
 	"github.com/joomcode/errorx"
 	"github.com/pingcap-incubator/tiup-cluster/pkg/log"
@@ -56,30 +54,30 @@ func newExecCmd() *cobra.Command {
 				return err
 			}
 
-			var hosts []string
 			filterRoles := set.NewStringSet(opt.roles...)
 			filterNodes := set.NewStringSet(opt.nodes...)
 
 			var shellTasks []task.Task
+			uniqueHosts := map[string]int{} // host -> ssh-port
 			metadata.Topology.IterInstance(func(inst meta.Instance) {
-				h := inst.GetHost()
-				if len(opt.roles) > 0 && !filterRoles.Exist(inst.Role()) {
-					return
-				}
+				if _, found := uniqueHosts[inst.GetHost()]; !found {
+					if len(opt.roles) > 0 && !filterRoles.Exist(inst.Role()) {
+						return
+					}
 
-				if len(opt.nodes) > 0 && !filterNodes.Exist(h) {
-					return
-				}
+					if len(opt.nodes) > 0 && !filterNodes.Exist(inst.GetHost()) {
+						return
+					}
 
-				hosts = append(hosts, h)
+					uniqueHosts[inst.GetHost()] = inst.GetSSHPort()
+				}
 			})
 
-			sort.Strings(hosts)
-			for i := 0; i < len(hosts); i++ {
-				if i > 0 && hosts[i] == hosts[i-1] {
-					continue
-				}
-				shellTasks = append(shellTasks, task.NewBuilder().Shell(hosts[i], opt.command, opt.sudo).Build())
+			for host := range uniqueHosts {
+				shellTasks = append(shellTasks,
+					task.NewBuilder().
+						Shell(host, opt.command, opt.sudo).
+						Build())
 			}
 
 			t := task.NewBuilder().
@@ -100,17 +98,14 @@ func newExecCmd() *cobra.Command {
 			}
 
 			// print outputs
-			for i := 0; i < len(hosts); i++ {
-				if i > 0 && hosts[i] == hosts[i-1] {
-					continue
-				}
-				stdout, stderr, ok := execCtx.GetOutputs(hosts[i])
+			for host := range uniqueHosts {
+				stdout, stderr, ok := execCtx.GetOutputs(host)
 				if !ok {
 					continue
 				}
 				log.Infof("Outputs of %s on %s:",
 					color.CyanString(opt.command),
-					color.CyanString(hosts[i]))
+					color.CyanString(host))
 				if len(stdout) > 0 {
 					log.Infof("%s:\n%s", color.GreenString("stdout"), stdout)
 				}

--- a/pkg/task/shell.go
+++ b/pkg/task/shell.go
@@ -34,9 +34,9 @@ func (m *Shell) Execute(ctx *Context) error {
 		return ErrNoExecutor
 	}
 
-	log.Infof("Run command on %s(sudo:%v): %s", m.host, m.sudo, m.cmd)
+	log.Infof("Run command on %s(sudo:%v): %s", m.host, m.sudo, m.command)
 
-	stdout, stderr, err := exec.Execute(m.cmd, m.sudo)
+	stdout, stderr, err := exec.Execute(m.command, m.sudo)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/pkg/task/shell.go
+++ b/pkg/task/shell.go
@@ -34,20 +34,13 @@ func (m *Shell) Execute(ctx *Context) error {
 		return ErrNoExecutor
 	}
 
-	var cmd string
+	log.Infof("Run command on %s(sudo:%v): %s", m.host, m.sudo, m.cmd)
 
-	if m.sudo {
-		cmd = fmt.Sprintf(`sudo %s`, m.command)
-	} else {
-		cmd = m.command
-	}
-
-	log.Infof("Run command on %s(sudo:%v): %s", m.host, m.sudo, cmd)
-
-	_, _, err := exec.Execute(cmd, false)
+	stdout, stderr, err := exec.Execute(m.cmd, m.sudo)
 	if err != nil {
 		return errors.Trace(err)
 	}
+	ctx.SetOutputs(m.host, stdout, stderr)
 
 	return nil
 }


### PR DESCRIPTION
 - Store `stdout` and `stderr` of shell commands in context
 - Display outputs of commands in `exec`