### PR TITLE
Check TiFlash when upgrading

### DIFF
--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -94,7 +94,7 @@ func upgrade(clusterName, clusterVersion string, opt upgradeOptions) error {
 	for _, comp := range metadata.Topology.ComponentsByStartOrder() {
 		for _, inst := range comp.Instances() {
 			version := bindversion.ComponentVersion(inst.ComponentName(), clusterVersion)
-			if version == "" {
+			if version == "" || inst.ComponentName() == "tiflash" {
 				return errors.Errorf("unsupported component: %v", inst.ComponentName())
 			}
 			compInfo := componentInfo{

--- a/pkg/meta/logic.go
+++ b/pkg/meta/logic.go
@@ -782,7 +782,7 @@ func (i *TiFlashInstance) InitConfig(e executor.TiOpsExecutor, clusterName, clus
 	}
 	tidbStatusStr := strings.Join(tidbStatusAddrs, ",")
 
-	pdAddrs := []string{}
+	var pdAddrs []string
 	for _, pd := range i.topo.PDServers {
 		pdAddrs = append(pdAddrs, fmt.Sprintf("%s:%d", pd.Host, uint64(pd.ClientPort)))
 	}


### PR DESCRIPTION
Temporarily upgrading if the previous cluster has TiFlash component.