### PR TITLE
support resource control configuration in topology.yaml

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -556,6 +556,7 @@ func buildMonitoredDeployTask(
 					clusterName,
 					comp,
 					host,
+					globalOptions.ResourceControl,
 					monitoredOptions,
 					globalOptions.User,
 					meta.DirPaths{

--- a/pkg/meta/topology.go
+++ b/pkg/meta/topology.go
@@ -47,23 +47,34 @@ type (
 		IsImported() bool
 	}
 
+	// ResourceControl is used to control the system resource
+	// See: https://www.freedesktop.org/software/systemd/man/systemd.resource-control.html
+	ResourceControl struct {
+		MemoryLimit         string `yaml:"memory_limit"`
+		CPUQuota            string `yaml:"cpu_quota"`
+		IOReadBandwidthMax  string `yaml:"io_read_bandwidth_max"`
+		IOWriteBandwidthMax string `yaml:"io_write_bandwidth_max"`
+	}
+
 	// GlobalOptions represents the global options for all groups in topology
 	// specification in topology.yaml
 	GlobalOptions struct {
-		User      string `yaml:"user,omitempty" default:"tidb"`
-		SSHPort   int    `yaml:"ssh_port,omitempty" default:"22"`
-		DeployDir string `yaml:"deploy_dir,omitempty" default:"deploy"`
-		DataDir   string `yaml:"data_dir,omitempty" default:"data"`
-		LogDir    string `yaml:"log_dir,omitempty"`
+		User            string          `yaml:"user,omitempty" default:"tidb"`
+		SSHPort         int             `yaml:"ssh_port,omitempty" default:"22"`
+		DeployDir       string          `yaml:"deploy_dir,omitempty" default:"deploy"`
+		DataDir         string          `yaml:"data_dir,omitempty" default:"data"`
+		LogDir          string          `yaml:"log_dir,omitempty"`
+		ResourceControl ResourceControl `yaml:"resource_control"`
 	}
 
 	// MonitoredOptions represents the monitored node configuration
 	MonitoredOptions struct {
-		NodeExporterPort     int    `yaml:"node_exporter_port,omitempty" default:"9100"`
-		BlackboxExporterPort int    `yaml:"blackbox_exporter_port,omitempty" default:"9115"`
-		DeployDir            string `yaml:"deploy_dir,omitempty"`
-		DataDir              string `yaml:"data_dir,omitempty"`
-		LogDir               string `yaml:"log_dir,omitempty"`
+		NodeExporterPort     int             `yaml:"node_exporter_port,omitempty" default:"9100"`
+		BlackboxExporterPort int             `yaml:"blackbox_exporter_port,omitempty" default:"9115"`
+		DeployDir            string          `yaml:"deploy_dir,omitempty"`
+		DataDir              string          `yaml:"data_dir,omitempty"`
+		LogDir               string          `yaml:"log_dir,omitempty"`
+		ResourceControl      ResourceControl `yaml:"resource_control"`
 	}
 
 	// ServerConfigs represents the server runtime configuration
@@ -96,15 +107,16 @@ type (
 
 // TiDBSpec represents the TiDB topology specification in topology.yaml
 type TiDBSpec struct {
-	Host       string                 `yaml:"host"`
-	SSHPort    int                    `yaml:"ssh_port,omitempty"`
-	Imported   bool                   `yaml:"imported,omitempty"`
-	Port       int                    `yaml:"port" default:"4000"`
-	StatusPort int                    `yaml:"status_port" default:"10080"`
-	DeployDir  string                 `yaml:"deploy_dir,omitempty"`
-	LogDir     string                 `yaml:"log_dir,omitempty"`
-	NumaNode   string                 `yaml:"numa_node,omitempty"`
-	Config     map[string]interface{} `yaml:"config,omitempty"`
+	Host            string                 `yaml:"host"`
+	SSHPort         int                    `yaml:"ssh_port,omitempty"`
+	Imported        bool                   `yaml:"imported,omitempty"`
+	Port            int                    `yaml:"port" default:"4000"`
+	StatusPort      int                    `yaml:"status_port" default:"10080"`
+	DeployDir       string                 `yaml:"deploy_dir,omitempty"`
+	LogDir          string                 `yaml:"log_dir,omitempty"`
+	NumaNode        string                 `yaml:"numa_node,omitempty"`
+	Config          map[string]interface{} `yaml:"config,omitempty"`
+	ResourceControl ResourceControl        `yaml:"resource_control"`
 }
 
 // statusByURL queries current status of the instance by http status api.
@@ -151,17 +163,18 @@ func (s TiDBSpec) IsImported() bool {
 
 // TiKVSpec represents the TiKV topology specification in topology.yaml
 type TiKVSpec struct {
-	Host       string                 `yaml:"host"`
-	SSHPort    int                    `yaml:"ssh_port,omitempty"`
-	Imported   bool                   `yaml:"imported,omitempty"`
-	Port       int                    `yaml:"port" default:"20160"`
-	StatusPort int                    `yaml:"status_port" default:"20180"`
-	DeployDir  string                 `yaml:"deploy_dir,omitempty"`
-	DataDir    string                 `yaml:"data_dir,omitempty"`
-	LogDir     string                 `yaml:"log_dir,omitempty"`
-	Offline    bool                   `yaml:"offline,omitempty"`
-	NumaNode   string                 `yaml:"numa_node,omitempty"`
-	Config     map[string]interface{} `yaml:"config,omitempty"`
+	Host            string                 `yaml:"host"`
+	SSHPort         int                    `yaml:"ssh_port,omitempty"`
+	Imported        bool                   `yaml:"imported,omitempty"`
+	Port            int                    `yaml:"port" default:"20160"`
+	StatusPort      int                    `yaml:"status_port" default:"20180"`
+	DeployDir       string                 `yaml:"deploy_dir,omitempty"`
+	DataDir         string                 `yaml:"data_dir,omitempty"`
+	LogDir          string                 `yaml:"log_dir,omitempty"`
+	Offline         bool                   `yaml:"offline,omitempty"`
+	NumaNode        string                 `yaml:"numa_node,omitempty"`
+	Config          map[string]interface{} `yaml:"config,omitempty"`
+	ResourceControl ResourceControl        `yaml:"resource_control"`
 }
 
 // Status queries current status of the instance
@@ -223,14 +236,15 @@ type PDSpec struct {
 	SSHPort  int    `yaml:"ssh_port,omitempty"`
 	Imported bool   `yaml:"imported,omitempty"`
 	// Use Name to get the name with a default value if it's empty.
-	Name       string                 `yaml:"name"`
-	ClientPort int                    `yaml:"client_port" default:"2379"`
-	PeerPort   int                    `yaml:"peer_port" default:"2380"`
-	DeployDir  string                 `yaml:"deploy_dir,omitempty"`
-	DataDir    string                 `yaml:"data_dir,omitempty"`
-	LogDir     string                 `yaml:"log_dir,omitempty"`
-	NumaNode   string                 `yaml:"numa_node,omitempty"`
-	Config     map[string]interface{} `yaml:"config,omitempty"`
+	Name            string                 `yaml:"name"`
+	ClientPort      int                    `yaml:"client_port" default:"2379"`
+	PeerPort        int                    `yaml:"peer_port" default:"2380"`
+	DeployDir       string                 `yaml:"deploy_dir,omitempty"`
+	DataDir         string                 `yaml:"data_dir,omitempty"`
+	LogDir          string                 `yaml:"log_dir,omitempty"`
+	NumaNode        string                 `yaml:"numa_node,omitempty"`
+	Config          map[string]interface{} `yaml:"config,omitempty"`
+	ResourceControl ResourceControl        `yaml:"resource_control"`
 }
 
 // Status queries current status of the instance
@@ -302,6 +316,7 @@ type TiFlashSpec struct {
 	NumaNode             string                 `yaml:"numa_node,omitempty"`
 	Config               map[string]interface{} `yaml:"config,omitempty"`
 	LearnerConfig        map[string]interface{} `yaml:"learner_config,omitempty"`
+	ResourceControl      ResourceControl        `yaml:"resource_control"`
 }
 
 // Status queries current status of the instance
@@ -332,16 +347,17 @@ func (s TiFlashSpec) IsImported() bool {
 
 // PumpSpec represents the Pump topology specification in topology.yaml
 type PumpSpec struct {
-	Host      string                 `yaml:"host"`
-	SSHPort   int                    `yaml:"ssh_port,omitempty"`
-	Imported  bool                   `yaml:"imported,omitempty"`
-	Port      int                    `yaml:"port" default:"8250"`
-	DeployDir string                 `yaml:"deploy_dir,omitempty"`
-	DataDir   string                 `yaml:"data_dir,omitempty"`
-	LogDir    string                 `yaml:"log_dir,omitempty"`
-	Offline   bool                   `yaml:"offline,omitempty"`
-	NumaNode  string                 `yaml:"numa_node,omitempty"`
-	Config    map[string]interface{} `yaml:"config,omitempty"`
+	Host            string                 `yaml:"host"`
+	SSHPort         int                    `yaml:"ssh_port,omitempty"`
+	Imported        bool                   `yaml:"imported,omitempty"`
+	Port            int                    `yaml:"port" default:"8250"`
+	DeployDir       string                 `yaml:"deploy_dir,omitempty"`
+	DataDir         string                 `yaml:"data_dir,omitempty"`
+	LogDir          string                 `yaml:"log_dir,omitempty"`
+	Offline         bool                   `yaml:"offline,omitempty"`
+	NumaNode        string                 `yaml:"numa_node,omitempty"`
+	Config          map[string]interface{} `yaml:"config,omitempty"`
+	ResourceControl ResourceControl        `yaml:"resource_control"`
 }
 
 // Role returns the component role of the instance
@@ -366,17 +382,18 @@ func (s PumpSpec) IsImported() bool {
 
 // DrainerSpec represents the Drainer topology specification in topology.yaml
 type DrainerSpec struct {
-	Host      string                 `yaml:"host"`
-	SSHPort   int                    `yaml:"ssh_port,omitempty"`
-	Imported  bool                   `yaml:"imported,omitempty"`
-	Port      int                    `yaml:"port" default:"8249"`
-	DeployDir string                 `yaml:"deploy_dir,omitempty"`
-	DataDir   string                 `yaml:"data_dir,omitempty"`
-	LogDir    string                 `yaml:"log_dir,omitempty"`
-	CommitTS  int64                  `yaml:"commit_ts,omitempty"`
-	Offline   bool                   `yaml:"offline,omitempty"`
-	NumaNode  string                 `yaml:"numa_node,omitempty"`
-	Config    map[string]interface{} `yaml:"config,omitempty"`
+	Host            string                 `yaml:"host"`
+	SSHPort         int                    `yaml:"ssh_port,omitempty"`
+	Imported        bool                   `yaml:"imported,omitempty"`
+	Port            int                    `yaml:"port" default:"8249"`
+	DeployDir       string                 `yaml:"deploy_dir,omitempty"`
+	DataDir         string                 `yaml:"data_dir,omitempty"`
+	LogDir          string                 `yaml:"log_dir,omitempty"`
+	CommitTS        int64                  `yaml:"commit_ts,omitempty"`
+	Offline         bool                   `yaml:"offline,omitempty"`
+	NumaNode        string                 `yaml:"numa_node,omitempty"`
+	Config          map[string]interface{} `yaml:"config,omitempty"`
+	ResourceControl ResourceControl        `yaml:"resource_control"`
 }
 
 // Role returns the component role of the instance
@@ -401,14 +418,15 @@ func (s DrainerSpec) IsImported() bool {
 
 // PrometheusSpec represents the Prometheus Server topology specification in topology.yaml
 type PrometheusSpec struct {
-	Host      string `yaml:"host"`
-	SSHPort   int    `yaml:"ssh_port,omitempty"`
-	Imported  bool   `yaml:"imported,omitempty"`
-	Port      int    `yaml:"port" default:"9090"`
-	DeployDir string `yaml:"deploy_dir,omitempty"`
-	DataDir   string `yaml:"data_dir,omitempty"`
-	LogDir    string `yaml:"log_dir,omitempty"`
-	Retention string `yaml:"storage_retention,omitempty"`
+	Host            string          `yaml:"host"`
+	SSHPort         int             `yaml:"ssh_port,omitempty"`
+	Imported        bool            `yaml:"imported,omitempty"`
+	Port            int             `yaml:"port" default:"9090"`
+	DeployDir       string          `yaml:"deploy_dir,omitempty"`
+	DataDir         string          `yaml:"data_dir,omitempty"`
+	LogDir          string          `yaml:"log_dir,omitempty"`
+	Retention       string          `yaml:"storage_retention,omitempty"`
+	ResourceControl ResourceControl `yaml:"resource_control"`
 }
 
 // Role returns the component role of the instance
@@ -433,11 +451,12 @@ func (s PrometheusSpec) IsImported() bool {
 
 // GrafanaSpec represents the Grafana topology specification in topology.yaml
 type GrafanaSpec struct {
-	Host      string `yaml:"host"`
-	SSHPort   int    `yaml:"ssh_port,omitempty"`
-	Imported  bool   `yaml:"imported,omitempty"`
-	Port      int    `yaml:"port" default:"3000"`
-	DeployDir string `yaml:"deploy_dir,omitempty"`
+	Host            string          `yaml:"host"`
+	SSHPort         int             `yaml:"ssh_port,omitempty"`
+	Imported        bool            `yaml:"imported,omitempty"`
+	Port            int             `yaml:"port" default:"3000"`
+	DeployDir       string          `yaml:"deploy_dir,omitempty"`
+	ResourceControl ResourceControl `yaml:"resource_control"`
 }
 
 // Role returns the component role of the instance
@@ -462,14 +481,15 @@ func (s GrafanaSpec) IsImported() bool {
 
 // AlertManagerSpec represents the AlertManager topology specification in topology.yaml
 type AlertManagerSpec struct {
-	Host        string `yaml:"host"`
-	SSHPort     int    `yaml:"ssh_port,omitempty"`
-	Imported    bool   `yaml:"imported,omitempty"`
-	WebPort     int    `yaml:"web_port" default:"9093"`
-	ClusterPort int    `yaml:"cluster_port" default:"9094"`
-	DeployDir   string `yaml:"deploy_dir,omitempty"`
-	DataDir     string `yaml:"data_dir,omitempty"`
-	LogDir      string `yaml:"log_dir,omitempty"`
+	Host            string          `yaml:"host"`
+	SSHPort         int             `yaml:"ssh_port,omitempty"`
+	Imported        bool            `yaml:"imported,omitempty"`
+	WebPort         int             `yaml:"web_port" default:"9093"`
+	ClusterPort     int             `yaml:"cluster_port" default:"9094"`
+	DeployDir       string          `yaml:"deploy_dir,omitempty"`
+	DataDir         string          `yaml:"data_dir,omitempty"`
+	LogDir          string          `yaml:"log_dir,omitempty"`
+	ResourceControl ResourceControl `yaml:"resource_control"`
 }
 
 // Role returns the component role of the instance

--- a/pkg/task/builder.go
+++ b/pkg/task/builder.go
@@ -175,11 +175,12 @@ func (b *Builder) ScaleConfig(clusterName, clusterVersion string, base *meta.Top
 }
 
 // MonitoredConfig appends a CopyComponent task to the current task collection
-func (b *Builder) MonitoredConfig(name, comp, host string, options meta.MonitoredOptions, deployUser string, paths meta.DirPaths) *Builder {
+func (b *Builder) MonitoredConfig(name, comp, host string, globResCtl meta.ResourceControl, options meta.MonitoredOptions, deployUser string, paths meta.DirPaths) *Builder {
 	b.tasks = append(b.tasks, &MonitoredConfig{
 		name:       name,
 		component:  comp,
 		host:       host,
+		globResCtl: globResCtl,
 		options:    options,
 		deployUser: deployUser,
 		paths:      paths,

--- a/pkg/template/systemd/system.go
+++ b/pkg/template/systemd/system.go
@@ -27,10 +27,10 @@ import (
 type Config struct {
 	ServiceName         string
 	User                string
-	MemoryLimit         uint
-	CPUQuota            uint
-	IOReadBandwidthMax  uint
-	IOWriteBandwidthMax uint
+	MemoryLimit         string
+	CPUQuota            string
+	IOReadBandwidthMax  string
+	IOWriteBandwidthMax string
 	DeployDir           string
 	DisableSendSigkill  bool
 	// Takes one of no, on-success, on-failure, on-abnormal, on-watchdog, on-abort, or always.
@@ -48,25 +48,25 @@ func NewConfig(service, user, deployDir string) *Config {
 }
 
 // WithMemoryLimit set the MemoryLimit field of Config
-func (c *Config) WithMemoryLimit(mem uint) *Config {
+func (c *Config) WithMemoryLimit(mem string) *Config {
 	c.MemoryLimit = mem
 	return c
 }
 
 // WithCPUQuota set the CPUQuota field of Config
-func (c *Config) WithCPUQuota(cpu uint) *Config {
+func (c *Config) WithCPUQuota(cpu string) *Config {
 	c.CPUQuota = cpu
 	return c
 }
 
 // WithIOReadBandwidthMax set the IOReadBandwidthMax field of Config
-func (c *Config) WithIOReadBandwidthMax(io uint) *Config {
+func (c *Config) WithIOReadBandwidthMax(io string) *Config {
 	c.IOReadBandwidthMax = io
 	return c
 }
 
 // WithIOWriteBandwidthMax set the IOWriteBandwidthMax field of Config
-func (c *Config) WithIOWriteBandwidthMax(io uint) *Config {
+func (c *Config) WithIOWriteBandwidthMax(io string) *Config {
 	c.IOWriteBandwidthMax = io
 	return c
 }

--- a/topology.example.yaml
+++ b/topology.example.yaml
@@ -6,6 +6,17 @@ global:
   ssh_port: 22
   deploy_dir: "/tidb-deploy"
   data_dir: "/tidb-data"
+  # # Resource Control is used to limit the resource of instance
+  # # See: https://www.freedesktop.org/software/systemd/man/systemd.resource-control.html
+  # # Supports using instance `resource_control` to override global `resource_control`
+  # resource_control:
+  #   # See: https://www.freedesktop.org/software/systemd/man/systemd.resource-control.html#IOReadBandwidthMax=device%20bytes
+  #   memory_limit: "2G"
+  #   # See: https://www.freedesktop.org/software/systemd/man/systemd.resource-control.html#IOReadBandwidthMax=device%20bytes
+  #   cpu_quota: "20%"
+  #   # See: https://www.freedesktop.org/software/systemd/man/systemd.resource-control.html#IOReadBandwidthMax=device%20bytes
+  #   io_read_bandwidth_max: "/dev/disk/by-path/pci-0000:00:1f.2-scsi-0:0:0:0 100M"
+  #   io_write_bandwidth_max: "/dev/disk/by-path/pci-0000:00:1f.2-scsi-0:0:0:0 100M"
 
 # # Monitored variables are used to all the machine
 monitored:


### PR DESCRIPTION
Signed-off-by: Lonng <heng@lonng.org>

Manually test:

1. topology

```yaml
global:
  user: tidb
  deploy_dir: "deploy"
  data_dir: "data"
  resource_control:
   # See: https://www.freedesktop.org/software/systemd/man/systemd.resource-control.html#IOReadBandwidthMax=device%20bytes
   memory_limit: "2G"
   # See: https://www.freedesktop.org/software/systemd/man/systemd.resource-control.html#IOReadBandwidthMax=device%20bytes
   cpu_quota: "20%"
   # See: https://www.freedesktop.org/software/systemd/man/systemd.resource-control.html#IOReadBandwidthMax=device%20bytes
   io_read_bandwidth_max: "/dev/disk/by-path/pci-0000:00:1f.2-scsi-0:0:0:0 100M"
   io_write_bandwidth_max: "/dev/disk/by-path/pci-0000:00:1f.2-scsi-0:0:0:0 100M"


monitored:
  node_exporter_port: 9101
  blackbox_exporter_port: 9111

tidb_servers:
  - host: 172.19.0.101

pd_servers:
  - host: 172.19.0.102
  - host: 172.19.0.104
  - host: 172.19.0.105

tikv_servers:
  - host: 172.19.0.103

grafana_servers:
  - host: 172.19.0.101

monitoring_servers:
  - host: 172.19.0.102

alertmanager_servers:
  - host: 172.19.0.103
```

2. deploy

```shell
tiup-cluster deploy test1 v4.0.0-rc bin/docker-scale.yaml -y -i ~/.ssh/id_rsa
```

3. start

```shell
tiup-cluster start test1
```

4. status
```shell
root@control:/tiup-cluster# tiup-cluster display test1
TiDB Cluster: test1
TiDB Version: v4.0.0-rc
ID                  Role          Host          Ports        Status     Data Dir                Deploy Dir
--                  ----          ----          -----        ------     --------                ----------
172.19.0.103:9093   alertmanager  172.19.0.103  9093/9094    Up         data/alertmanager-9093  deploy/alertmanager-9093
172.19.0.101:3000   grafana       172.19.0.101  3000         Up         -                       deploy/grafana-3000
172.19.0.102:2379   pd            172.19.0.102  2379/2380    Healthy    data/pd-2379            deploy/pd-2379
172.19.0.104:2379   pd            172.19.0.104  2379/2380    Healthy|L  data/pd-2379            deploy/pd-2379
172.19.0.105:2379   pd            172.19.0.105  2379/2380    Healthy    data/pd-2379            deploy/pd-2379
172.19.0.102:9090   prometheus    172.19.0.102  9090         Up         data/prometheus-9090    deploy/prometheus-9090
172.19.0.101:4000   tidb          172.19.0.101  4000/10080   Up         -                       deploy/tidb-4000
172.19.0.103:20160  tikv          172.19.0.103  20160/20180  Up         data/tikv-20160         deploy/tikv-20160
root@control:/tiup-cluster#
```