### PR TITLE
Fix download ignore error

### DIFF
--- a/pkg/task/download.go
+++ b/pkg/task/download.go
@@ -76,12 +76,12 @@ func (d *Downloader) Execute(_ *Context) error {
 
 		err = repo.Mirror().Download(fileName, meta.ProfilePath(meta.TiOpsPackageCacheDir))
 		if err != nil {
-			return nil
+			return errors.AddStack(err)
 		}
 
 		err = repo.Mirror().Download(sha1File, meta.ProfilePath(meta.TiOpsPackageCacheDir))
 		if err != nil {
-			return nil
+			return errors.AddStack(err)
 		}
 
 		shaPath := meta.ProfilePath(meta.TiOpsPackageCacheDir, sha1File)
@@ -94,6 +94,7 @@ func (d *Downloader) Execute(_ *Context) error {
 		if err != nil {
 			return errors.Trace(err)
 		}
+
 		err = utils.CheckSHA(file, string(sha))
 		_ = file.Close()
 


### PR DESCRIPTION

maybe fix:

```
  - Copy tidb -> 172.19.0.102 ... Done
  - Copy tiflash -> 172.19.0.103 ... Error
  - Copy drainer -> 172.19.0.101 ... Done
  - Copy prometheus -> 172.19.0.101 ... Done
  - Copy grafana -> 172.19.0.101 ... Done
  - Copy alertmanager -> 172.19.0.101 ... Done
  - Copy node_exporter -> 172.19.0.104 ... Done
  - Copy node_exporter -> 172.19.0.105 ... Done
  - Copy node_exporter -> 172.19.0.102 ... Done
  - Copy node_exporter -> 172.19.0.101 ... Done
  - Copy node_exporter -> 172.19.0.103 ... Done
  - Copy blackbox_exporter -> 172.19.0.103 ... Done
  - Copy blackbox_exporter -> 172.19.0.104 ... Done
  - Copy blackbox_exporter -> 172.19.0.105 ... Done
  - Copy blackbox_exporter -> 172.19.0.102 ... Done
  - Copy blackbox_exporter -> 172.19.0.101 ... Done

Error: stderr: gzip: stdin: unexpected end of file
tar: Unexpected EOF in archive
tar: Unexpected EOF in archive
tar: Error is not recoverable: exiting now
: executor.ssh.execute_failed: Failed to execute command over SSH for 'tidb@172.19.0.103:22' {ssh_stderr: gzip: stdin: unexpected end of file
tar: Unexpected EOF in archive
tar: Unexpected EOF in archive
tar: Error is not recoverable: exiting now
, ssh_stdout: , ssh_command: PATH=$PATH:/usr/bin:/usr/sbin tar -xzf /home/tidb/deploy/tiflash-9000/bin/tiflash-v4.0.0-rc-linux-amd64.tar.gz -C /home/tidb/deploy/tiflash-9000/bin && rm /home/tidb/deploy/tiflash-9000/bin/tiflash-v4.0.0-rc-linux-amd64.tar.gz}, cause: Process exited with status 2
```

note the file is not complete but no error report at the download task.