### PR TITLE
Fix grammar and format for topology.example.yaml

### DIFF
--- a/topology.example.yaml
+++ b/topology.example.yaml
@@ -1,14 +1,14 @@
-# # Global variables are applied to all deployments and as the default value of
-# # them if the specific deployment value missing.
+# # Global variables are applied to all deployments and used as the default value of
+# # the deployments if a specific deployment value is missing.
 
 global:
   user: "tidb"
   ssh_port: 22
   deploy_dir: "/tidb-deploy"
   data_dir: "/tidb-data"
-  # # Resource Control is used to limit the resource of instance
+  # # Resource Control is used to limit the resource of an instance.
   # # See: https://www.freedesktop.org/software/systemd/man/systemd.resource-control.html
-  # # Supports using instance `resource_control` to override global `resource_control`
+  # # Supports using instance-level `resource_control` to override global `resource_control`.
   # resource_control:
   #   # See: https://www.freedesktop.org/software/systemd/man/systemd.resource-control.html#IOReadBandwidthMax=device%20bytes
   #   memory_limit: "2G"
@@ -18,15 +18,15 @@ global:
   #   io_read_bandwidth_max: "/dev/disk/by-path/pci-0000:00:1f.2-scsi-0:0:0:0 100M"
   #   io_write_bandwidth_max: "/dev/disk/by-path/pci-0000:00:1f.2-scsi-0:0:0:0 100M"
 
-# # Monitored variables are used to all the machine
+# # Monitored variables are applied to all the machines.
 monitored:
-  node_exporter_port: 9100
+  node_exporter_port: 9100 
   blackbox_exporter_port: 9115
   # deploy_dir: "/tidb-deploy/monitored-9100"
   # data_dir: "/tidb-data/monitored-9100"
   # log_dir: "/tidb-deploy/monitored-9100/log"
 
-# # Server configs are used to specify the runtime configuration of TiDB components
+# # Server configs are used to specify the runtime configuration of TiDB components.
 # # All configuration items can be found in TiDB docs:
 # #
 # # - TiDB: https://pingcap.com/docs/stable/reference/configuration/tidb-server/configuration-file/
@@ -36,7 +36,7 @@ monitored:
 # # All configuration items use points to represent the hierarchy, e.g:
 # #   readpool.storage.use-unified-pool
 # #           ^       ^
-# # You can overwrite this configuration via instance-level `config` field
+# # You can overwrite this configuration via the instance-level `config` field.
 
 server_configs:
   tidb:
@@ -72,7 +72,7 @@ pd_servers:
     # data_dir: "/tidb-data/pd-2379"
     # log_dir: "/tidb-deploy/pd-2379/log"
     # numa_node: "0,1"
-    # # Config is used to overwrite the `server_configs.pd` values
+    # # The following configs are used to overwrite the `server_configs.pd` values.
     # config:
     #   schedule.max-merge-region-size: 20
     #   schedule.max-merge-region-keys: 200000
@@ -87,7 +87,7 @@ tidb_servers:
     # deploy_dir: "/tidb-deploy/tidb-4000"
     # log_dir: "/tidb-deploy/tidb-4000/log"
     # numa_node: "0,1"
-    # # Config is used to overwrite the `server_configs.tidb` values
+    # # The following configs are used to overwrite the `server_configs.tidb` values.
     # config:
     #   log.level: warn
     #   log.slow-query-file: tidb-slow-overwrited.log
@@ -102,7 +102,7 @@ tikv_servers:
     # data_dir: "/tidb-data/tikv-20160"
     # log_dir: "/tidb-deploy/tikv-20160/log"
     # numa_node: "0,1"
-    # # Config is used to overwrite the `server_configs.tikv` values
+    # # The following configs are used to overwrite the `server_configs.tikv` values.
     # config:
     #   server.grpc-concurrency: 4
     #   server.labels: { zone: "zone1", dc: "dc1", host: "host1" }
@@ -122,7 +122,7 @@ tiflash_servers:
     # data_dir: /tidb-data/tiflash-9000
     # log_dir: /tidb-deploy/tiflash-9000/log
     # numa_node: "0,1"
-    # # Config is used to overwrite the `server_configs.tiflash` values
+    # # The following configs are used to overwrite the `server_configs.tiflash` values.
     # config:
     #   logger.level: "info"
     # learner_config:
@@ -138,7 +138,7 @@ tiflash_servers:
 #     data_dir: "/tidb-data/pump-8249"
 #     log_dir: "/tidb-deploy/pump-8249/log"
 #     numa_node: "0,1"
-#     # Config is used to overwrite the `server_configs.drainer` values
+#     # The following configs are used to overwrite the `server_configs.drainer` values.
 #     config:
 #       gc: 7
 #   - host: 10.0.1.18
@@ -148,13 +148,13 @@ tiflash_servers:
 #   - host: 10.0.1.17
 #     port: 8249
 #     data_dir: "/tidb-data/drainer-8249"
-#     # if drainer doesn't have checkpoint, use initial commitTS to initial checkpoint
-#     # will get a latest timestamp from pd if setting to be -1 (default -1)
+#     # If drainer doesn't have a checkpoint, use initial commitTS as the initial checkpoint.
+#     # Will get a latest timestamp from pd if commit_ts is set to -1 (the default value).
 #     commit_ts: -1
 #     deploy_dir: "/tidb-deploy/drainer-8249"
 #     log_dir: "/tidb-deploy/drainer-8249/log"
 #     numa_node: "0,1"
-#     # Config is used to overwrite the `server_configs.drainer` values
+#     # The following configs are used to overwrite the `server_configs.drainer` values.
 #     config:
 #       syncer.db-type: "mysql"
 #       syncer.to.host: "127.0.0.1"

--- a/topology.example.yaml
+++ b/topology.example.yaml
@@ -20,7 +20,7 @@ global:
 
 # # Monitored variables are applied to all the machines.
 monitored:
-  node_exporter_port: 9100 
+  node_exporter_port: 9100
   blackbox_exporter_port: 9115
   # deploy_dir: "/tidb-deploy/monitored-9100"
   # data_dir: "/tidb-data/monitored-9100"


### PR DESCRIPTION
1. Fix grammar mistakes
2. Unify format