### PR TITLE
Collect integrate test coverage

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -33,6 +33,12 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha  }}
           path: go/src/github.com/${{ github.repository  }}
+      - name: Build build_integration_test
+        working-directory: ${{env.working-directory}}
+        run: |
+          export GOPATH=${GITHUB_WORKSPACE}/go
+          export PATH=$PATH:$GOPATH/bin
+          make build_integration_test
 
       - name: Build the docker-compose stack
         working-directory: ${{env.working-directory}}
@@ -80,6 +86,66 @@ jobs:
           free -h
           "cat ./tests/*.log" || true
 
+      - name: Upload cover files
+        working-directory: ${{env.working-directory}}
+        uses: actions/upload-artifact@v1
+        with:
+          name: ${{matrix.cases}}-cover
+          path: path/to/artifact
+
+
+
       # - name: Setup tmate session
       #   if: always()
       #   uses: mxschmitt/action-tmate@v2
+  coverage:
+    needs: case
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha  }}
+          path: go/src/github.com/${{ github.repository  }}
+
+      - name: make unit-test
+        working-directory: ${{env.working-directory}}
+        run: |
+          export GOPATH=${GITHUB_WORKSPACE}/go
+          export PATH=$PATH:$GOPATH/bin
+          make unit-test
+
+      - uses: actions/download-artifact@v1
+        working-directory: ${{env.working-directory}}
+        with:
+          name: test_cmd-cover
+          path: ${{env.working-directory}}/cover
+
+      - uses: actions/download-artifact@v1
+        working-directory: ${{env.working-directory}}
+        with:
+          name: test_upgrade-cover
+          path: ${{env.working-directory}}/cover
+
+      - name: Make coverage
+        working-directory: ${{env.working-directory}}
+        run: |
+          export GOPATH=${GITHUB_WORKSPACE}/go
+          export PATH=$PATH:$GOPATH/bin
+          make coverage
+
+      - name: Upload all cover files
+        working-directory: ${{env.working-directory}}
+        uses: actions/upload-artifact@v1
+        with:
+          name: all-cover
+          path: ${{env.working-directory}}/cover
+
+      - name: Upload coverage to Codecov
+        working-directory: ${{env.working-directory}}
+        uses: codecov/codecov-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          file: cover/all_cov.out
+          flags: coverage
+          name: codecov-umbrella
+          fail_ci_if_error: true

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -90,7 +90,7 @@ jobs:
         uses: actions/upload-artifact@v1
         with:
           name: ${{matrix.cases}}-cover
-          path: ${{env.working-directory}}/cover
+          path: ${{env.working-directory}}/tests/cover
 
 
       # - name: Setup tmate session

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -87,12 +87,10 @@ jobs:
           "cat ./tests/*.log" || true
 
       - name: Upload cover files
-        working-directory: ${{env.working-directory}}
         uses: actions/upload-artifact@v1
         with:
           name: ${{matrix.cases}}-cover
-          path: path/to/artifact
-
+          path: ${{env.working-directory}}/cover
 
 
       # - name: Setup tmate session
@@ -141,11 +139,10 @@ jobs:
           path: ${{env.working-directory}}/cover
 
       - name: Upload coverage to Codecov
-        working-directory: ${{env.working-directory}}
         uses: codecov/codecov-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          file: cover/all_cov.out
+          file: ${{env.working-directory}}/cover/all_cov.out
           flags: coverage
           name: codecov-umbrella
           fail_ci_if_error: true

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -98,6 +98,9 @@ jobs:
       #   uses: mxschmitt/action-tmate@v2
   coverage:
     needs: case
+    runs-on: ubuntu-latest
+    env:
+      working-directory: ${{ github.workspace   }}/go/src/github.com/${{ github.repository   }}
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -141,7 +141,6 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
           file: ${{env.working-directory}}/cover/all_cov.out
           flags: coverage
           name: codecov-umbrella

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -113,13 +113,11 @@ jobs:
           make unit-test
 
       - uses: actions/download-artifact@v1
-        working-directory: ${{env.working-directory}}
         with:
           name: test_cmd-cover
           path: ${{env.working-directory}}/cover
 
       - uses: actions/download-artifact@v1
-        working-directory: ${{env.working-directory}}
         with:
           name: test_upgrade-cover
           path: ${{env.working-directory}}/cover
@@ -132,7 +130,6 @@ jobs:
           make coverage
 
       - name: Upload all cover files
-        working-directory: ${{env.working-directory}}
         uses: actions/upload-artifact@v1
         with:
           name: all-cover

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -197,7 +197,9 @@ func Execute() {
 
 	color.Unset()
 
-	os.Exit(code)
+	if code != 0 {
+		os.Exit(code)
+	}
 }
 
 func beautifyCobraUsageAndHelp(rootCmd *cobra.Command) {

--- a/go.sum
+++ b/go.sum
@@ -33,8 +33,6 @@ github.com/alexbrainman/odbc v0.0.0-20190102080306-cf37ce290779/go.mod h1:WEQLoR
 github.com/amsokol/ignite-go-client v0.12.2/go.mod h1:K3tKJGcLQORFD+ds7f0f9fl88tv0KZcpfuNhzRyuLVE=
 github.com/antihax/optional v0.0.0-20180407024304-ca021399b1a6/go.mod h1:V8iCPQYkqmusNa815XgQio277wI47sdRh1dUOLdyC6Q=
 github.com/apache/calcite-avatica-go/v4 v4.0.0/go.mod h1:fg6MgnbY4Ta6JI0KuNaL9o/LrOMZdprQSMHWflcNs1c=
-github.com/appleboy/easyssh-proxy v1.3.0 h1:ToH+hZDPWP9/9E58lwxDLJQSHvgGgDAQ9ZVx6x5oofI=
-github.com/appleboy/easyssh-proxy v1.3.0/go.mod h1:Kk57I3w7OCafOjp5kgZFvxk2fO8Tca5CriBTOsbSbjY=
 github.com/appleboy/easyssh-proxy v1.3.1 h1:zj5u800KIRPziMlJouhd2R6jufz6ihGlFSmojzXYSOw=
 github.com/appleboy/easyssh-proxy v1.3.1/go.mod h1:Kk57I3w7OCafOjp5kgZFvxk2fO8Tca5CriBTOsbSbjY=
 github.com/appleboy/gin-jwt/v2 v2.6.3/go.mod h1:MfPYA4ogzvOcVkRwAxT7quHOtQmVKDpTwxyUrC2DNw0=
@@ -55,6 +53,7 @@ github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cheggaaa/pb v2.0.7+incompatible h1:gLKifR1UkZ/kLkda5gC0K6c8g+jU2sINPtBeOiNlMhU=
 github.com/cheggaaa/pb v2.0.7+incompatible/go.mod h1:pQciLPpbU0oxA0h+VJYYLxO+XeDQb5pZijXscXHm81s=
+github.com/cheynewallace/tabby v1.1.0 h1:XtG/ZanoIvNZHfe0cClhWLzD/16GGF9UD7mMdWwYnCQ=
 github.com/cheynewallace/tabby v1.1.0/go.mod h1:Pba/6cUL8uYqvOc9RkyvFbHGrQ9wShyrn6/S/1OYVys=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20171208011716-f6d7a1f6fbf3/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=

--- a/main_test.go
+++ b/main_test.go
@@ -17,8 +17,6 @@ import (
 	"os"
 	"strings"
 	"testing"
-
-	"github.com/pingcap-incubator/tiup-cluster/cmd"
 )
 
 // To build:
@@ -47,6 +45,6 @@ func TestMain(t *testing.T) {
 	// fmt.Println(os.Args)
 
 	if run {
-		cmd.Execute()
+		main()
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,52 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/pingcap-incubator/tiup-cluster/cmd"
+)
+
+// To build:
+// see build_integration_test in Makefile
+// To run:
+// tiup-cluster.test  -test.coverprofile={file} __DEVEL--i-heard-you-like-tests
+
+func TestMain(t *testing.T) {
+	var (
+		args []string
+		run  bool
+	)
+
+	for _, arg := range os.Args {
+		switch {
+		case arg == "__DEVEL--i-heard-you-like-tests":
+			run = true
+		case strings.HasPrefix(arg, "-test"):
+		case strings.HasPrefix(arg, "__DEVEL"):
+		default:
+			args = append(args, arg)
+		}
+	}
+	os.Args = args
+
+	// fmt.Println(os.Args)
+
+	if run {
+		cmd.Execute()
+	}
+}

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -14,6 +14,15 @@ export TIUP_CLUSTER_EXECUTE_DEFAULT_TIMEOUT=300s
 export version=${version-v4.0.0-rc}
 export old_version=${old_version-v3.0.12}
 
+function tiup-cluster() {
+	# echo "in function"
+	if [ -f "./bin/tiup-cluster.test" ]; then
+	  ./bin/tiup-cluster.test  -test.coverprofile=./cover/cov.itest-$(date +'%s')-$RANDOM.out __DEVEL--i-heard-you-like-tests $@
+    else
+	  tiup-cluster $@
+	fi
+}
+
 . ./script/util.sh
 
 # TODO remove this once embed the files in binary

--- a/tests/script/util.sh
+++ b/tests/script/util.sh
@@ -4,9 +4,12 @@ set -eu
 
 # instance_num <name>
 # get the instance number of the cluster
+# filter the output of the go test
+# PASS
+# coverage: 12.7% of statements in github.com/pingcap-incubator/tiup-cluster/...
 function instance_num() {
 	name=$1
-	line=$(tiup-cluster display $name | wc -l)
+	line=$(tiup-cluster display $name | grep -v "PASS" | grep -v "coverage" | wc -l)
 	count=`expr $line - 4`
 
 	echo $count


### PR DESCRIPTION
support generate cover of integrate test and merge all test including unit test:

- support build a go test binary
- in the integration workflow upload the cover file after each job running  integration test
- after all job of integration test finished, download  the cover files and run unit test for merging the unit test cover file too.


the current coverage is: 57.90%
see for detail:
https://codecov.io/gh/pingcap-incubator/tiup-cluster/tree/a7263c72e96d4100fbd0c410e69ffd437f0369e9/go/src/github.com/pingcap-incubator/tiup-cluster