### PR TITLE
No need to set TIUP_CLUSTER_ROOT in dev

### DIFF
--- a/docker/control/Dockerfile
+++ b/docker/control/Dockerfile
@@ -13,10 +13,8 @@ RUN sed -i 's/deb.debian.org/mirrors.aliyun.com/g' /etc/apt/sources.list
      apt-get -y -q install software-properties-common && \
      apt-get install -qqy \
          dos2unix \
-         git \
-         wget \
          default-mysql-client \
-	     vim pssh # not required by tiup-cluster itself, just for ease of use
+	     vim # not required by tiup-cluster itself, just for ease of use
 
 
 # without --dev flag up.sh copies tiup-cluster to these subfolders

--- a/docker/control/Dockerfile
+++ b/docker/control/Dockerfile
@@ -2,10 +2,8 @@ FROM golang:1.14
 
 
 # Use mirrors for poor network...
-RUN sed -i 's/archive.ubuntu.com/mirrors.aliyun.com/g' /etc/apt/sources.list
-RUN sed -i 's/security.ubuntu.com/mirrors.aliyun.com/g' /etc/apt/sources.list
 RUN sed -i 's/deb.debian.org/mirrors.aliyun.com/g' /etc/apt/sources.list
-# RUN sed -i 's/security.debian.org/mirrors.aliyun.com/g' /etc/apt/sources.list
+RUN sed -i 's/security.debian.org/mirrors.aliyun.com/g' /etc/apt/sources.list
 
 
 # tiup-cluster dependencies

--- a/docker/node/Dockerfile
+++ b/docker/node/Dockerfile
@@ -1,12 +1,11 @@
 # Based on the deprecated `https://github.com/tutumcloud/tutum-debian`
-FROM debian:stretch
+FROM golang:1.14
 
 # Install packages
 RUN apt-get update && \
     apt-get -y install \
         dos2unix \
         openssh-server \
-        pwgen \
         && \
 mkdir -p /var/run/sshd && \
 sed -i "s/UsePrivilegeSeparation.*/UsePrivilegeSeparation no/g" /etc/ssh/sshd_config && \
@@ -19,13 +18,8 @@ ADD run.sh /run.sh
 RUN dos2unix /run.sh \
     && chmod +x /*.sh
 
-RUN apt-get update
-RUN apt install -y apt-transport-https
-RUN apt install -y software-properties-common
-
 # Install deps
-RUN apt-get install -y build-essential bzip2 curl faketime iproute iptables iputils-ping libzip4 logrotate man man-db net-tools ntpdate psmisc python rsyslog sudo tar unzip vim wget
-# && apt-get remove -y --purge --auto-remove systemd
+RUN apt-get install -qqy sudo vim
 
 EXPOSE 22
 CMD ["/run.sh"]

--- a/docker/node/Dockerfile
+++ b/docker/node/Dockerfile
@@ -1,6 +1,10 @@
 # Based on the deprecated `https://github.com/tutumcloud/tutum-debian`
 FROM golang:1.14
 
+# Use mirrors for poor network...
+RUN sed -i 's/deb.debian.org/mirrors.aliyun.com/g' /etc/apt/sources.list
+RUN sed -i 's/security.debian.org/mirrors.aliyun.com/g' /etc/apt/sources.list
+
 # Install packages
 RUN apt-get update && \
     apt-get -y install \

--- a/docker/up.sh
+++ b/docker/up.sh
@@ -52,7 +52,7 @@ do
             ;;
         --dev)
             if [ ! "$TIUP_CLUSTER_ROOT" ]; then
-                TIUP_CLUSTER_ROOT="$(cd ../ && pwd)"
+                export TIUP_CLUSTER_ROOT="$(cd ../ && pwd)"
                 INFO "TIUP_CLUSTER_ROOT is not set, defaulting to: $TIUP_CLUSTER_ROOT"
             fi
             INFO "Running docker-compose with dev config"


### PR DESCRIPTION
- No need to set TIUP_CLUSTER_ROOT in `--dev` (set the repo default)
- simplify the docker file and use the same base image.
