### PR TITLE
tests: add `check` command to test script

### DIFF
--- a/tests/test_cmd.sh
+++ b/tests/test_cmd.sh
@@ -8,9 +8,9 @@ topo=./topo/full.yaml
 
 tiup-cluster check $topo -i ~/.ssh/id_rsa --enable-mem --enable-cpu --apply
 
-yes | tiup-cluster check $topo -i ~/.ssh/id_rsa
+tiup-cluster --yes check $topo -i ~/.ssh/id_rsa
 
-yes | tiup-cluster deploy $name $version $topo -i ~/.ssh/id_rsa
+tiup-cluster --yes deploy $name $version $topo -i ~/.ssh/id_rsa
 
 tiup-cluster list | grep "$name"
 
@@ -21,13 +21,13 @@ id=`tiup-cluster audit | grep "deploy $name $version" | awk '{print $1}'`
 tiup-cluster audit $id
 
 
-yes | tiup-cluster start $name
+tiup-cluster --yes start $name
 
 tiup-cluster _test $name writable
 
-yes | tiup-cluster stop $name
+tiup-cluster --yes stop $name
 
-yes | tiup-cluster restart $name
+tiup-cluster --yes restart $name
 
 tiup-cluster _test $name writable
 
@@ -36,28 +36,28 @@ tiup-cluster display $name
 totol_sub_one=19
 
 echo "start scale in tidb"
-yes | tiup-cluster scale-in $name -N 172.19.0.101:4000
+tiup-cluster --yes scale-in $name -N 172.19.0.101:4000
 wait_instance_num_reach $name $totol_sub_one
 echo "start scale out tidb"
-yes | tiup-cluster scale-out $name ./topo/full_scale_in_tidb.yaml
+tiup-cluster --yes scale-out $name ./topo/full_scale_in_tidb.yaml
 
 echo "start scale in tikv"
-yes | tiup-cluster scale-in $name -N 172.19.0.103:20160
+tiup-cluster --yes scale-in $name -N 172.19.0.103:20160
 wait_instance_num_reach $name $totol_sub_one
 echo "start scale out tikv"
-yes | tiup-cluster scale-out $name ./topo/full_scale_in_tikv.yaml
+tiup-cluster --yes scale-out $name ./topo/full_scale_in_tikv.yaml
 
 echo "start scale in pd"
-yes | tiup-cluster scale-in $name -N 172.19.0.103:2379
+tiup-cluster --yes scale-in $name -N 172.19.0.103:2379
 wait_instance_num_reach $name $totol_sub_one
 echo "start scale out pd"
-yes | tiup-cluster scale-out $name ./topo/full_scale_in_pd.yaml
+tiup-cluster --yes scale-out $name ./topo/full_scale_in_pd.yaml
 
 echo "start scale in pump"
-yes | tiup-cluster scale-in $name -N 172.19.0.103:8250
+tiup-cluster --yes scale-in $name -N 172.19.0.103:8250
 wait_instance_num_reach $name $totol_sub_one
 echo "start scale out pump"
-yes | tiup-cluster scale-out $name ./topo/full_scale_in_pump.yaml
+tiup-cluster --yes scale-out $name ./topo/full_scale_in_pump.yaml
 
 echo "start scale in cdc"
 yes | tiup-cluster scale-in $name -N 172.19.0.103:8300
@@ -66,12 +66,12 @@ echo "start scale out cdc"
 yes | tiup-cluster scale-out $name ./topo/full_scale_in_cdc.yaml
 
 echo "start scale in grafana"
-yes | tiup-cluster scale-in $name -N 172.19.0.101:3000
+tiup-cluster --yes scale-in $name -N 172.19.0.101:3000
 wait_instance_num_reach $name $totol_sub_one
 echo "start scale out grafana"
-yes | tiup-cluster scale-out $name ./topo/full_scale_in_grafana.yaml
+tiup-cluster --yes scale-out $name ./topo/full_scale_in_grafana.yaml
 
 tiup-cluster _test $name writable
 
-yes | tiup-cluster destroy $name
+tiup-cluster --yes destroy $name
 

--- a/tests/test_cmd.sh
+++ b/tests/test_cmd.sh
@@ -6,6 +6,9 @@ version=${version-v4.0.0-rc}
 name=test_cmd
 topo=./topo/full.yaml
 
+tiup-cluster check $topo -i ~/.ssh/id_rsa --enable-mem --enable-cpu --apply
+
+yes | tiup-cluster check $topo -i ~/.ssh/id_rsa
 
 yes | tiup-cluster deploy $name $version $topo -i ~/.ssh/id_rsa
 


### PR DESCRIPTION
Run `check` twice before `deploy`, the first round enables all checks (except `fio`) and tries to apply any supported fixes. The second round should observe less failed checks.