### PR TITLE
support upgrade tiflash

### DIFF
--- a/cmd/cluster/command/upgrade.go
+++ b/cmd/cluster/command/upgrade.go
@@ -95,7 +95,7 @@ func upgrade(clusterName, clusterVersion string, opt upgradeOptions) error {
 	for _, comp := range metadata.Topology.ComponentsByStartOrder() {
 		for _, inst := range comp.Instances() {
 			version := bindversion.ComponentVersion(inst.ComponentName(), clusterVersion)
-			if version == "" || inst.ComponentName() == "tiflash" {
+			if version == "" {
 				return errors.Errorf("unsupported component: %v", inst.ComponentName())
 			}
 			compInfo := componentInfo{


### PR DESCRIPTION
Signed-off-by: Lonng <heng@lonng.org>

- topology

```yaml
global:
  user: tidb
  deploy_dir: "deploy"
  data_dir: "data"
  resource_control:
   # See: https://www.freedesktop.org/software/systemd/man/systemd.resource-control.html#IOReadBandwidthMax=device%20bytes
   memory_limit: "2G"
   # See: https://www.freedesktop.org/software/systemd/man/systemd.resource-control.html#IOReadBandwidthMax=device%20bytes
   cpu_quota: "20%"
   # See: https://www.freedesktop.org/software/systemd/man/systemd.resource-control.html#IOReadBandwidthMax=device%20bytes
   io_read_bandwidth_max: "/dev/disk/by-path/pci-0000:00:1f.2-scsi-0:0:0:0 100M"
   io_write_bandwidth_max: "/dev/disk/by-path/pci-0000:00:1f.2-scsi-0:0:0:0 100M"


monitored:
  node_exporter_port: 9101
  blackbox_exporter_port: 9111

tidb_servers:
  - host: 172.19.0.101

pd_servers:
  - host: 172.19.0.102
  - host: 172.19.0.104
  - host: 172.19.0.105

tikv_servers:
  - host: 172.19.0.103

grafana_servers:
  - host: 172.19.0.101

tiflash_servers:
  - host: 172.19.0.102

monitoring_servers:
  - host: 172.19.0.102

alertmanager_servers:
  - host: 172.19.0.103
```

- deploy

```
root@control:/tiup-cluster# tiup cluster deploy test v3.1.0-rc topoloy.yaml
root@control:/tiup-cluster# tiup-cluster start test
root@control:/tiup-cluster# tiup-cluster upgrade test v4.0.0-rc
root@control:/tiup-cluster# tiup-cluster display test
TiDB Cluster: test
TiDB Version: v4.0.0-rc
ID                  Role          Host          Ports                            Status     Data Dir                Deploy Dir
--                  ----          ----          -----                            ------     --------                ----------
172.19.0.103:9093   alertmanager  172.19.0.103  9093/9094                        Up         data/alertmanager-9093  deploy/alertmanager-9093
172.19.0.101:3000   grafana       172.19.0.101  3000                             Up         -                       deploy/grafana-3000
172.19.0.102:2379   pd            172.19.0.102  2379/2380                        Healthy|L  data/pd-2379            deploy/pd-2379
172.19.0.104:2379   pd            172.19.0.104  2379/2380                        Healthy    data/pd-2379            deploy/pd-2379
172.19.0.105:2379   pd            172.19.0.105  2379/2380                        Healthy    data/pd-2379            deploy/pd-2379
172.19.0.102:9090   prometheus    172.19.0.102  9090                             Up         data/prometheus-9090    deploy/prometheus-9090
172.19.0.101:4000   tidb          172.19.0.101  4000/10080                       Up         -                       deploy/tidb-4000
172.19.0.102:9000   tiflash       172.19.0.102  9000/8123/3930/20170/20292/8234  Up         data/tiflash-9000       deploy/tiflash-9000
172.19.0.103:20160  tikv          172.19.0.103  20160/20180                      Up         data/tikv-20160         deploy/tikv-20160
root@control:/tiup-cluster#
```