### PR TITLE
cmd: fix incorrect data_dir

### DIFF
--- a/cmd/cluster/command/check.go
+++ b/cmd/cluster/command/check.go
@@ -23,6 +23,7 @@ import (
 	"github.com/joomcode/errorx"
 	"github.com/pingcap-incubator/tiup-cluster/pkg/cliutil"
 	"github.com/pingcap-incubator/tiup-cluster/pkg/cliutil/prepare"
+	"github.com/pingcap-incubator/tiup-cluster/pkg/clusterutil"
 	"github.com/pingcap-incubator/tiup-cluster/pkg/log"
 	"github.com/pingcap-incubator/tiup-cluster/pkg/logger"
 	"github.com/pingcap-incubator/tiup-cluster/pkg/meta"
@@ -129,11 +130,10 @@ func checkSystemInfo(s *cliutil.SSHConnectionProps, topo *meta.TopologySpecifica
 				BuildAsStep(fmt.Sprintf("  - Getting system info of %s:%d", inst.GetHost(), inst.GetSSHPort()))
 			collectTasks = append(collectTasks, t1)
 
-			dataDir := inst.DataDir()
-			// the default data_dir is relative to deploy_dir
-			if dataDir != "" && !strings.HasPrefix(dataDir, "/") {
-				dataDir = filepath.Join(inst.DeployDir(), dataDir)
-			}
+			// if the data dir set in topology is relative, and the home dir of deploy user
+			// and the user run the check command is on different partitions, the disk detection
+			// may be using incorrect partition for validations.
+			dataDir := clusterutil.Abs(opt.user, inst.DataDir())
 
 			// build checking tasks
 			t2 := task.NewBuilder().

--- a/cmd/cluster/command/check.go
+++ b/cmd/cluster/command/check.go
@@ -129,18 +129,24 @@ func checkSystemInfo(s *cliutil.SSHConnectionProps, topo *meta.TopologySpecifica
 				BuildAsStep(fmt.Sprintf("  - Getting system info of %s:%d", inst.GetHost(), inst.GetSSHPort()))
 			collectTasks = append(collectTasks, t1)
 
+			dataDir := inst.DataDir()
+			// the default data_dir is relative to deploy_dir
+			if dataDir != "" && !strings.HasPrefix(dataDir, "/") {
+				dataDir = filepath.Join(inst.DeployDir(), dataDir)
+			}
+
 			// build checking tasks
 			t2 := task.NewBuilder().
 				CheckSys(
 					inst.GetHost(),
-					inst.DataDir(),
+					dataDir,
 					task.CheckTypeSystemInfo,
 					topo,
 					opt.opr,
 				).
 				CheckSys(
 					inst.GetHost(),
-					inst.DataDir(),
+					dataDir,
 					task.CheckTypePartitions,
 					topo,
 					opt.opr,
@@ -152,7 +158,7 @@ func checkSystemInfo(s *cliutil.SSHConnectionProps, topo *meta.TopologySpecifica
 				).
 				CheckSys(
 					inst.GetHost(),
-					inst.DataDir(),
+					dataDir,
 					task.CheckTypePort,
 					topo,
 					opt.opr,
@@ -164,7 +170,7 @@ func checkSystemInfo(s *cliutil.SSHConnectionProps, topo *meta.TopologySpecifica
 				).
 				CheckSys(
 					inst.GetHost(),
-					inst.DataDir(),
+					dataDir,
 					task.CheckTypeSystemLimits,
 					topo,
 					opt.opr,
@@ -176,28 +182,28 @@ func checkSystemInfo(s *cliutil.SSHConnectionProps, topo *meta.TopologySpecifica
 				).
 				CheckSys(
 					inst.GetHost(),
-					inst.DataDir(),
+					dataDir,
 					task.CheckTypeSystemConfig,
 					topo,
 					opt.opr,
 				).
 				CheckSys(
 					inst.GetHost(),
-					inst.DataDir(),
+					dataDir,
 					task.CheckTypeService,
 					topo,
 					opt.opr,
 				).
 				CheckSys(
 					inst.GetHost(),
-					inst.DataDir(),
+					dataDir,
 					task.CheckTypePackage,
 					topo,
 					opt.opr,
 				).
 				CheckSys(
 					inst.GetHost(),
-					inst.DataDir(),
+					dataDir,
 					task.CheckTypeFIO,
 					topo,
 					opt.opr,

--- a/cmd/cluster/command/deploy.go
+++ b/cmd/cluster/command/deploy.go
@@ -209,11 +209,7 @@ func deploy(clusterName, clusterVersion, topoFile string, opt deployOptions) err
 		version := meta.ComponentVersion(inst.ComponentName(), clusterVersion)
 		deployDir := clusterutil.Abs(globalOptions.User, inst.DeployDir())
 		// data dir would be empty for components which don't need it
-		dataDir := inst.DataDir()
-		// the default data_dir is relative to deploy_dir
-		if dataDir != "" && !strings.HasPrefix(dataDir, "/") {
-			dataDir = filepath.Join(deployDir, dataDir)
-		}
+		dataDir := clusterutil.Abs(globalOptions.User, inst.DataDir())
 		// log dir will always be with values, but might not used by the component
 		logDir := clusterutil.Abs(globalOptions.User, inst.LogDir())
 		// Deploy component

--- a/cmd/cluster/command/deploy.go
+++ b/cmd/cluster/command/deploy.go
@@ -207,7 +207,7 @@ func deploy(clusterName, clusterVersion, topoFile string, opt deployOptions) err
 		// data dir would be empty for components which don't need it
 		dataDir := inst.DataDir()
 		if dataDir != "" {
-			clusterutil.Abs(globalOptions.User, dataDir)
+			dataDir = clusterutil.Abs(globalOptions.User, dataDir)
 		}
 		// log dir will always be with values, but might not used by the component
 		logDir := clusterutil.Abs(globalOptions.User, inst.LogDir())
@@ -295,7 +295,7 @@ func buildMonitoredDeployTask(
 			// data dir would be empty for components which don't need it
 			dataDir := monitoredOptions.DataDir
 			if dataDir != "" {
-				clusterutil.Abs(globalOptions.User, dataDir)
+				dataDir = clusterutil.Abs(globalOptions.User, dataDir)
 			}
 			// log dir will always be with values, but might not used by the component
 			logDir := clusterutil.Abs(globalOptions.User, monitoredOptions.LogDir)

--- a/cmd/cluster/command/deploy.go
+++ b/cmd/cluster/command/deploy.go
@@ -178,6 +178,10 @@ func deploy(clusterName, clusterVersion, topoFile string, opt deployOptions) err
 				if dir == "" {
 					continue
 				}
+				// the dafault, relative path of data dir is under deploy dir
+				if !strings.HasPrefix(globalOptions.DataDir, "/") {
+					continue
+				}
 				dirs = append(dirs, clusterutil.Abs(globalOptions.User, dir))
 			}
 			t := task.NewBuilder().
@@ -206,6 +210,10 @@ func deploy(clusterName, clusterVersion, topoFile string, opt deployOptions) err
 		deployDir := clusterutil.Abs(globalOptions.User, inst.DeployDir())
 		// data dir would be empty for components which don't need it
 		dataDir := inst.DataDir()
+		// the default data_dir is relative to deploy_dir
+		if dataDir != "" && !strings.HasPrefix(dataDir, "/") {
+			dataDir = filepath.Join(deployDir, dataDir)
+		}
 		// log dir will always be with values, but might not used by the component
 		logDir := clusterutil.Abs(globalOptions.User, inst.LogDir())
 		// Deploy component
@@ -291,6 +299,10 @@ func buildMonitoredDeployTask(
 			deployDir := clusterutil.Abs(globalOptions.User, monitoredOptions.DeployDir)
 			// data dir would be empty for components which don't need it
 			dataDir := monitoredOptions.DataDir
+			// the default data_dir is relative to deploy_dir
+			if dataDir != "" && !strings.HasPrefix(dataDir, "/") {
+				dataDir = filepath.Join(deployDir, dataDir)
+			}
 			// log dir will always be with values, but might not used by the component
 			logDir := clusterutil.Abs(globalOptions.User, monitoredOptions.LogDir)
 

--- a/cmd/cluster/command/deploy.go
+++ b/cmd/cluster/command/deploy.go
@@ -206,9 +206,6 @@ func deploy(clusterName, clusterVersion, topoFile string, opt deployOptions) err
 		deployDir := clusterutil.Abs(globalOptions.User, inst.DeployDir())
 		// data dir would be empty for components which don't need it
 		dataDir := inst.DataDir()
-		if dataDir != "" {
-			dataDir = clusterutil.Abs(globalOptions.User, dataDir)
-		}
 		// log dir will always be with values, but might not used by the component
 		logDir := clusterutil.Abs(globalOptions.User, inst.LogDir())
 		// Deploy component
@@ -294,9 +291,6 @@ func buildMonitoredDeployTask(
 			deployDir := clusterutil.Abs(globalOptions.User, monitoredOptions.DeployDir)
 			// data dir would be empty for components which don't need it
 			dataDir := monitoredOptions.DataDir
-			if dataDir != "" {
-				dataDir = clusterutil.Abs(globalOptions.User, dataDir)
-			}
 			// log dir will always be with values, but might not used by the component
 			logDir := clusterutil.Abs(globalOptions.User, monitoredOptions.LogDir)
 

--- a/cmd/cluster/command/deploy.go
+++ b/cmd/cluster/command/deploy.go
@@ -174,15 +174,15 @@ func deploy(clusterName, clusterVersion, topoFile string, opt deployOptions) err
 		if _, found := uniqueHosts[inst.GetHost()]; !found {
 			uniqueHosts[inst.GetHost()] = inst.GetSSHPort()
 			var dirs []string
-			for _, dir := range []string{globalOptions.DeployDir, globalOptions.DataDir, globalOptions.LogDir} {
+			for _, dir := range []string{globalOptions.DeployDir, globalOptions.LogDir} {
 				if dir == "" {
 					continue
 				}
-				// the dafault, relative path of data dir is under deploy dir
-				if !strings.HasPrefix(globalOptions.DataDir, "/") {
-					continue
-				}
 				dirs = append(dirs, clusterutil.Abs(globalOptions.User, dir))
+			}
+			// the dafault, relative path of data dir is under deploy dir
+			if strings.HasPrefix(globalOptions.DataDir, "/") {
+				dirs = append(dirs, globalOptions.DataDir)
 			}
 			t := task.NewBuilder().
 				RootSSH(

--- a/cmd/cluster/command/reload.go
+++ b/cmd/cluster/command/reload.go
@@ -92,9 +92,6 @@ func buildReloadTask(
 		deployDir := clusterutil.Abs(metadata.User, inst.DeployDir())
 		// data dir would be empty for components which don't need it
 		dataDir := inst.DataDir()
-		if dataDir != "" {
-			dataDir = clusterutil.Abs(metadata.User, dataDir)
-		}
 		// log dir will always be with values, but might not used by the component
 		logDir := clusterutil.Abs(metadata.User, inst.LogDir())
 

--- a/cmd/cluster/command/reload.go
+++ b/cmd/cluster/command/reload.go
@@ -14,9 +14,6 @@
 package command
 
 import (
-	"path/filepath"
-	"strings"
-
 	"github.com/joomcode/errorx"
 	"github.com/pingcap-incubator/tiup-cluster/pkg/clusterutil"
 	"github.com/pingcap-incubator/tiup-cluster/pkg/log"
@@ -94,11 +91,7 @@ func buildReloadTask(
 	topo.IterInstance(func(inst meta.Instance) {
 		deployDir := clusterutil.Abs(metadata.User, inst.DeployDir())
 		// data dir would be empty for components which don't need it
-		dataDir := inst.DataDir()
-		// the default data_dir is relative to deploy_dir
-		if dataDir != "" && !strings.HasPrefix(dataDir, "/") {
-			dataDir = filepath.Join(deployDir, dataDir)
-		}
+		dataDir := clusterutil.Abs(metadata.User, inst.DataDir())
 		// log dir will always be with values, but might not used by the component
 		logDir := clusterutil.Abs(metadata.User, inst.LogDir())
 

--- a/cmd/cluster/command/reload.go
+++ b/cmd/cluster/command/reload.go
@@ -14,6 +14,9 @@
 package command
 
 import (
+	"path/filepath"
+	"strings"
+
 	"github.com/joomcode/errorx"
 	"github.com/pingcap-incubator/tiup-cluster/pkg/clusterutil"
 	"github.com/pingcap-incubator/tiup-cluster/pkg/log"
@@ -92,6 +95,10 @@ func buildReloadTask(
 		deployDir := clusterutil.Abs(metadata.User, inst.DeployDir())
 		// data dir would be empty for components which don't need it
 		dataDir := inst.DataDir()
+		// the default data_dir is relative to deploy_dir
+		if dataDir != "" && !strings.HasPrefix(dataDir, "/") {
+			dataDir = filepath.Join(deployDir, dataDir)
+		}
 		// log dir will always be with values, but might not used by the component
 		logDir := clusterutil.Abs(metadata.User, inst.LogDir())
 

--- a/cmd/cluster/command/reload.go
+++ b/cmd/cluster/command/reload.go
@@ -93,7 +93,7 @@ func buildReloadTask(
 		// data dir would be empty for components which don't need it
 		dataDir := inst.DataDir()
 		if dataDir != "" {
-			clusterutil.Abs(metadata.User, dataDir)
+			dataDir = clusterutil.Abs(metadata.User, dataDir)
 		}
 		// log dir will always be with values, but might not used by the component
 		logDir := clusterutil.Abs(metadata.User, inst.LogDir())

--- a/cmd/cluster/command/scale_in.go
+++ b/cmd/cluster/command/scale_in.go
@@ -14,7 +14,6 @@
 package command
 
 import (
-	"path/filepath"
 	"strings"
 
 	"github.com/fatih/color"
@@ -89,11 +88,7 @@ func scaleIn(clusterName string, options operator.Options) error {
 			}
 			deployDir := clusterutil.Abs(metadata.User, instance.DeployDir())
 			// data dir would be empty for components which don't need it
-			dataDir := instance.DataDir()
-			// the default data_dir is relative to deploy_dir
-			if dataDir != "" && !strings.HasPrefix(dataDir, "/") {
-				dataDir = filepath.Join(deployDir, dataDir)
-			}
+			dataDir := clusterutil.Abs(metadata.User, instance.DataDir())
 			// log dir will always be with values, but might not used by the component
 			logDir := clusterutil.Abs(metadata.User, instance.LogDir())
 

--- a/cmd/cluster/command/scale_in.go
+++ b/cmd/cluster/command/scale_in.go
@@ -14,6 +14,7 @@
 package command
 
 import (
+	"path/filepath"
 	"strings"
 
 	"github.com/fatih/color"
@@ -89,6 +90,10 @@ func scaleIn(clusterName string, options operator.Options) error {
 			deployDir := clusterutil.Abs(metadata.User, instance.DeployDir())
 			// data dir would be empty for components which don't need it
 			dataDir := instance.DataDir()
+			// the default data_dir is relative to deploy_dir
+			if dataDir != "" && !strings.HasPrefix(dataDir, "/") {
+				dataDir = filepath.Join(deployDir, dataDir)
+			}
 			// log dir will always be with values, but might not used by the component
 			logDir := clusterutil.Abs(metadata.User, instance.LogDir())
 

--- a/cmd/cluster/command/scale_in.go
+++ b/cmd/cluster/command/scale_in.go
@@ -89,9 +89,6 @@ func scaleIn(clusterName string, options operator.Options) error {
 			deployDir := clusterutil.Abs(metadata.User, instance.DeployDir())
 			// data dir would be empty for components which don't need it
 			dataDir := instance.DataDir()
-			if dataDir != "" {
-				dataDir = clusterutil.Abs(metadata.User, dataDir)
-			}
 			// log dir will always be with values, but might not used by the component
 			logDir := clusterutil.Abs(metadata.User, instance.LogDir())
 

--- a/cmd/cluster/command/scale_in.go
+++ b/cmd/cluster/command/scale_in.go
@@ -90,7 +90,7 @@ func scaleIn(clusterName string, options operator.Options) error {
 			// data dir would be empty for components which don't need it
 			dataDir := instance.DataDir()
 			if dataDir != "" {
-				clusterutil.Abs(metadata.User, dataDir)
+				dataDir = clusterutil.Abs(metadata.User, dataDir)
 			}
 			// log dir will always be with values, but might not used by the component
 			logDir := clusterutil.Abs(metadata.User, instance.LogDir())

--- a/cmd/cluster/command/scale_out.go
+++ b/cmd/cluster/command/scale_out.go
@@ -14,8 +14,8 @@
 package command
 
 import (
-	"path"
 	"path/filepath"
+	"strings"
 
 	"github.com/joomcode/errorx"
 	"github.com/pingcap-incubator/tiup-cluster/pkg/cliutil"
@@ -41,7 +41,7 @@ type scaleOutOptions struct {
 
 func newScaleOutCmd() *cobra.Command {
 	opt := scaleOutOptions{
-		identityFile: path.Join(utils.UserHome(), ".ssh", "id_rsa"),
+		identityFile: filepath.Join(utils.UserHome(), ".ssh", "id_rsa"),
 	}
 	cmd := &cobra.Command{
 		Use:          "scale-out <cluster-name> <topology.yaml>",
@@ -202,6 +202,10 @@ func buildScaleOutTask(
 		deployDir := clusterutil.Abs(metadata.User, inst.DeployDir())
 		// data dir would be empty for components which don't need it
 		dataDir := inst.DataDir()
+		// the default data_dir is relative to deploy_dir
+		if dataDir != "" && !strings.HasPrefix(dataDir, "/") {
+			dataDir = filepath.Join(deployDir, dataDir)
+		}
 		// log dir will always be with values, but might not used by the component
 		logDir := clusterutil.Abs(metadata.User, inst.LogDir())
 
@@ -236,6 +240,10 @@ func buildScaleOutTask(
 		deployDir := clusterutil.Abs(metadata.User, inst.DeployDir())
 		// data dir would be empty for components which don't need it
 		dataDir := inst.DataDir()
+		// the default data_dir is relative to deploy_dir
+		if dataDir != "" && !strings.HasPrefix(dataDir, "/") {
+			dataDir = filepath.Join(deployDir, dataDir)
+		}
 		// log dir will always be with values, but might not used by the component
 		logDir := clusterutil.Abs(metadata.User, inst.LogDir())
 

--- a/cmd/cluster/command/scale_out.go
+++ b/cmd/cluster/command/scale_out.go
@@ -15,7 +15,6 @@ package command
 
 import (
 	"path/filepath"
-	"strings"
 
 	"github.com/joomcode/errorx"
 	"github.com/pingcap-incubator/tiup-cluster/pkg/cliutil"
@@ -201,11 +200,7 @@ func buildScaleOutTask(
 		version := meta.ComponentVersion(inst.ComponentName(), metadata.Version)
 		deployDir := clusterutil.Abs(metadata.User, inst.DeployDir())
 		// data dir would be empty for components which don't need it
-		dataDir := inst.DataDir()
-		// the default data_dir is relative to deploy_dir
-		if dataDir != "" && !strings.HasPrefix(dataDir, "/") {
-			dataDir = filepath.Join(deployDir, dataDir)
-		}
+		dataDir := clusterutil.Abs(metadata.User, inst.DataDir())
 		// log dir will always be with values, but might not used by the component
 		logDir := clusterutil.Abs(metadata.User, inst.LogDir())
 
@@ -239,11 +234,7 @@ func buildScaleOutTask(
 	mergedTopo.IterInstance(func(inst meta.Instance) {
 		deployDir := clusterutil.Abs(metadata.User, inst.DeployDir())
 		// data dir would be empty for components which don't need it
-		dataDir := inst.DataDir()
-		// the default data_dir is relative to deploy_dir
-		if dataDir != "" && !strings.HasPrefix(dataDir, "/") {
-			dataDir = filepath.Join(deployDir, dataDir)
-		}
+		dataDir := clusterutil.Abs(metadata.User, inst.DataDir())
 		// log dir will always be with values, but might not used by the component
 		logDir := clusterutil.Abs(metadata.User, inst.LogDir())
 

--- a/cmd/cluster/command/scale_out.go
+++ b/cmd/cluster/command/scale_out.go
@@ -203,7 +203,7 @@ func buildScaleOutTask(
 		// data dir would be empty for components which don't need it
 		dataDir := inst.DataDir()
 		if dataDir != "" {
-			clusterutil.Abs(metadata.User, dataDir)
+			dataDir = clusterutil.Abs(metadata.User, dataDir)
 		}
 		// log dir will always be with values, but might not used by the component
 		logDir := clusterutil.Abs(metadata.User, inst.LogDir())
@@ -240,7 +240,7 @@ func buildScaleOutTask(
 		// data dir would be empty for components which don't need it
 		dataDir := inst.DataDir()
 		if dataDir != "" {
-			clusterutil.Abs(metadata.User, dataDir)
+			dataDir = clusterutil.Abs(metadata.User, dataDir)
 		}
 		// log dir will always be with values, but might not used by the component
 		logDir := clusterutil.Abs(metadata.User, inst.LogDir())

--- a/cmd/cluster/command/scale_out.go
+++ b/cmd/cluster/command/scale_out.go
@@ -202,9 +202,6 @@ func buildScaleOutTask(
 		deployDir := clusterutil.Abs(metadata.User, inst.DeployDir())
 		// data dir would be empty for components which don't need it
 		dataDir := inst.DataDir()
-		if dataDir != "" {
-			dataDir = clusterutil.Abs(metadata.User, dataDir)
-		}
 		// log dir will always be with values, but might not used by the component
 		logDir := clusterutil.Abs(metadata.User, inst.LogDir())
 
@@ -239,9 +236,6 @@ func buildScaleOutTask(
 		deployDir := clusterutil.Abs(metadata.User, inst.DeployDir())
 		// data dir would be empty for components which don't need it
 		dataDir := inst.DataDir()
-		if dataDir != "" {
-			dataDir = clusterutil.Abs(metadata.User, dataDir)
-		}
 		// log dir will always be with values, but might not used by the component
 		logDir := clusterutil.Abs(metadata.User, inst.LogDir())
 

--- a/cmd/cluster/command/upgrade.go
+++ b/cmd/cluster/command/upgrade.go
@@ -15,8 +15,6 @@ package command
 
 import (
 	"os"
-	"path/filepath"
-	"strings"
 
 	"github.com/joomcode/errorx"
 	"github.com/pingcap-incubator/tiup-cluster/pkg/clusterutil"
@@ -115,11 +113,7 @@ func upgrade(clusterName, clusterVersion string, opt upgradeOptions) error {
 
 			deployDir := clusterutil.Abs(metadata.User, inst.DeployDir())
 			// data dir would be empty for components which don't need it
-			dataDir := inst.DataDir()
-			// the default data_dir is relative to deploy_dir
-			if dataDir != "" && !strings.HasPrefix(dataDir, "/") {
-				dataDir = filepath.Join(deployDir, dataDir)
-			}
+			dataDir := clusterutil.Abs(metadata.User, inst.DataDir())
 			// log dir will always be with values, but might not used by the component
 			logDir := clusterutil.Abs(metadata.User, inst.LogDir())
 

--- a/cmd/cluster/command/upgrade.go
+++ b/cmd/cluster/command/upgrade.go
@@ -15,6 +15,8 @@ package command
 
 import (
 	"os"
+	"path/filepath"
+	"strings"
 
 	"github.com/joomcode/errorx"
 	"github.com/pingcap-incubator/tiup-cluster/pkg/clusterutil"
@@ -114,6 +116,10 @@ func upgrade(clusterName, clusterVersion string, opt upgradeOptions) error {
 			deployDir := clusterutil.Abs(metadata.User, inst.DeployDir())
 			// data dir would be empty for components which don't need it
 			dataDir := inst.DataDir()
+			// the default data_dir is relative to deploy_dir
+			if dataDir != "" && !strings.HasPrefix(dataDir, "/") {
+				dataDir = filepath.Join(deployDir, dataDir)
+			}
 			// log dir will always be with values, but might not used by the component
 			logDir := clusterutil.Abs(metadata.User, inst.LogDir())
 

--- a/cmd/cluster/command/upgrade.go
+++ b/cmd/cluster/command/upgrade.go
@@ -115,7 +115,7 @@ func upgrade(clusterName, clusterVersion string, opt upgradeOptions) error {
 			// data dir would be empty for components which don't need it
 			dataDir := inst.DataDir()
 			if dataDir != "" {
-				clusterutil.Abs(metadata.User, dataDir)
+				dataDir = clusterutil.Abs(metadata.User, dataDir)
 			}
 			// log dir will always be with values, but might not used by the component
 			logDir := clusterutil.Abs(metadata.User, inst.LogDir())

--- a/cmd/cluster/command/upgrade.go
+++ b/cmd/cluster/command/upgrade.go
@@ -114,9 +114,6 @@ func upgrade(clusterName, clusterVersion string, opt upgradeOptions) error {
 			deployDir := clusterutil.Abs(metadata.User, inst.DeployDir())
 			// data dir would be empty for components which don't need it
 			dataDir := inst.DataDir()
-			if dataDir != "" {
-				dataDir = clusterutil.Abs(metadata.User, dataDir)
-			}
 			// log dir will always be with values, but might not used by the component
 			logDir := clusterutil.Abs(metadata.User, inst.LogDir())
 

--- a/cmd/dm/command/deploy.go
+++ b/cmd/dm/command/deploy.go
@@ -200,6 +200,10 @@ func deploy(clusterName, clusterVersion, topoFile string, opt deployOptions) err
 		deployDir := clusterutil.Abs(globalOptions.User, inst.DeployDir())
 		// data dir would be empty for components which don't need it
 		dataDir := inst.DataDir()
+		// the default data_dir is relative to deploy_dir
+		if dataDir != "" && !strings.HasPrefix(dataDir, "/") {
+			dataDir = filepath.Join(deployDir, dataDir)
+		}
 		// log dir will always be with values, but might not used by the component
 		logDir := clusterutil.Abs(globalOptions.User, inst.LogDir())
 		// Deploy component

--- a/cmd/dm/command/deploy.go
+++ b/cmd/dm/command/deploy.go
@@ -201,7 +201,7 @@ func deploy(clusterName, clusterVersion, topoFile string, opt deployOptions) err
 		// data dir would be empty for components which don't need it
 		dataDir := inst.DataDir()
 		if dataDir != "" {
-			clusterutil.Abs(globalOptions.User, dataDir)
+			dataDir = clusterutil.Abs(globalOptions.User, dataDir)
 		}
 		// log dir will always be with values, but might not used by the component
 		logDir := clusterutil.Abs(globalOptions.User, inst.LogDir())

--- a/cmd/dm/command/deploy.go
+++ b/cmd/dm/command/deploy.go
@@ -200,9 +200,6 @@ func deploy(clusterName, clusterVersion, topoFile string, opt deployOptions) err
 		deployDir := clusterutil.Abs(globalOptions.User, inst.DeployDir())
 		// data dir would be empty for components which don't need it
 		dataDir := inst.DataDir()
-		if dataDir != "" {
-			dataDir = clusterutil.Abs(globalOptions.User, dataDir)
-		}
 		// log dir will always be with values, but might not used by the component
 		logDir := clusterutil.Abs(globalOptions.User, inst.LogDir())
 		// Deploy component

--- a/cmd/dm/command/deploy.go
+++ b/cmd/dm/command/deploy.go
@@ -203,11 +203,7 @@ func deploy(clusterName, clusterVersion, topoFile string, opt deployOptions) err
 		version := meta.ComponentVersion(inst.ComponentName(), clusterVersion)
 		deployDir := clusterutil.Abs(globalOptions.User, inst.DeployDir())
 		// data dir would be empty for components which don't need it
-		dataDir := inst.DataDir()
-		// the default data_dir is relative to deploy_dir
-		if dataDir != "" && !strings.HasPrefix(dataDir, "/") {
-			dataDir = filepath.Join(deployDir, dataDir)
-		}
+		dataDir := clusterutil.Abs(globalOptions.User, inst.DataDir())
 		// log dir will always be with values, but might not used by the component
 		logDir := clusterutil.Abs(globalOptions.User, inst.LogDir())
 		// Deploy component

--- a/cmd/dm/command/deploy.go
+++ b/cmd/dm/command/deploy.go
@@ -168,11 +168,15 @@ func deploy(clusterName, clusterVersion, topoFile string, opt deployOptions) err
 		if _, found := uniqueHosts[inst.GetHost()]; !found {
 			uniqueHosts[inst.GetHost()] = inst.GetSSHPort()
 			var dirs []string
-			for _, dir := range []string{globalOptions.DeployDir, globalOptions.DataDir, globalOptions.LogDir} {
+			for _, dir := range []string{globalOptions.DeployDir, globalOptions.LogDir} {
 				if dir == "" {
 					continue
 				}
 				dirs = append(dirs, clusterutil.Abs(globalOptions.User, dir))
+			}
+			// the dafault, relative path of data dir is under deploy dir
+			if strings.HasPrefix(globalOptions.DataDir, "/") {
+				dirs = append(dirs, globalOptions.DataDir)
 			}
 			t := task.NewBuilder().
 				RootSSH(

--- a/pkg/cliutil/prepare/prepare.go
+++ b/pkg/cliutil/prepare/prepare.go
@@ -18,6 +18,7 @@ import (
 	"io/ioutil"
 	"os"
 	"strconv"
+	"strings"
 
 	"github.com/joomcode/errorx"
 	"github.com/pingcap-incubator/tiup-cluster/pkg/cliutil"
@@ -142,6 +143,11 @@ func CheckClusterDirConflict(clusterName string, topo meta.Specification) error 
 	})
 
 	for _, d1 := range currentEntries {
+		// data_dir is relative to deploy_dir by default, so they can be with
+		// same (sub) paths as long as the deploy_dirs are different
+		if d1.dirKind == "data directory" && !strings.HasPrefix(d1.dir, "/") {
+			continue
+		}
 		for _, d2 := range existingEntries {
 			if d1.instance.GetHost() != d2.instance.GetHost() {
 				continue

--- a/pkg/meta/cluster.go
+++ b/pkg/meta/cluster.go
@@ -21,6 +21,7 @@ import (
 	"github.com/pingcap-incubator/tiup-cluster/pkg/cliutil"
 	"github.com/pingcap-incubator/tiup-cluster/pkg/file"
 	"github.com/pingcap-incubator/tiup-cluster/pkg/utils"
+	"github.com/pingcap-incubator/tiup-cluster/pkg/version"
 	"github.com/pingcap/errors"
 	"gopkg.in/yaml.v2"
 )
@@ -48,6 +49,7 @@ type ClusterMeta struct {
 	Version string `yaml:"tidb_version"` // the version of TiDB cluster
 	//EnableTLS      bool   `yaml:"enable_tls"`
 	//EnableFirewall bool   `yaml:"firewall"`
+	OpsVer string `yaml:"last_ops_ver,omitempty"` // the version of ourself that updated the meta last time
 
 	Topology *TopologySpecification `yaml:"topology"`
 }
@@ -70,6 +72,9 @@ func SaveClusterMeta(clusterName string, meta *ClusterMeta) error {
 
 	metaFile := ClusterPath(clusterName, MetaFileName)
 	backupDir := ClusterPath(clusterName, BackupDirName)
+
+	// set the cmd version
+	meta.OpsVer = version.NewTiOpsVersion().FullInfo()
 
 	if err := EnsureClusterDir(clusterName); err != nil {
 		return wrapError(err)

--- a/pkg/meta/logic.go
+++ b/pkg/meta/logic.go
@@ -251,7 +251,8 @@ func (i *instance) DataDir() string {
 	if !dataDir.IsValid() {
 		return ""
 	}
-	return dataDir.Interface().(string)
+
+	return dataDir.String()
 }
 
 // MergeResourceControl merge the rhs into lhs and overwrite rhs if lhs has value for same field

--- a/pkg/meta/logic.go
+++ b/pkg/meta/logic.go
@@ -1385,7 +1385,7 @@ func (topo *ClusterSpecification) Endpoints(user string) []*scripts.PDScript {
 		// data dir would be empty for components which don't need it
 		dataDir := spec.DataDir
 		if dataDir != "" {
-			clusterutil.Abs(user, dataDir)
+			dataDir = clusterutil.Abs(user, dataDir)
 		}
 		// log dir will always be with values, but might not used by the component
 		logDir := clusterutil.Abs(user, spec.LogDir)
@@ -1411,7 +1411,7 @@ func (topo *ClusterSpecification) AlertManagerEndpoints(user string) []*scripts.
 		// data dir would be empty for components which don't need it
 		dataDir := spec.DataDir
 		if dataDir != "" {
-			clusterutil.Abs(user, dataDir)
+			dataDir = clusterutil.Abs(user, dataDir)
 		}
 		// log dir will always be with values, but might not used by the component
 		logDir := clusterutil.Abs(user, spec.LogDir)

--- a/pkg/meta/logic.go
+++ b/pkg/meta/logic.go
@@ -1384,6 +1384,10 @@ func (topo *ClusterSpecification) Endpoints(user string) []*scripts.PDScript {
 		deployDir := clusterutil.Abs(user, spec.DeployDir)
 		// data dir would be empty for components which don't need it
 		dataDir := spec.DataDir
+		// the default data_dir is relative to deploy_dir
+		if dataDir != "" && !strings.HasPrefix(dataDir, "/") {
+			dataDir = filepath.Join(deployDir, dataDir)
+		}
 		// log dir will always be with values, but might not used by the component
 		logDir := clusterutil.Abs(user, spec.LogDir)
 
@@ -1407,6 +1411,10 @@ func (topo *ClusterSpecification) AlertManagerEndpoints(user string) []*scripts.
 		deployDir := clusterutil.Abs(user, spec.DeployDir)
 		// data dir would be empty for components which don't need it
 		dataDir := spec.DataDir
+		// the default data_dir is relative to deploy_dir
+		if dataDir != "" && !strings.HasPrefix(dataDir, "/") {
+			dataDir = filepath.Join(deployDir, dataDir)
+		}
 		// log dir will always be with values, but might not used by the component
 		logDir := clusterutil.Abs(user, spec.LogDir)
 

--- a/pkg/meta/logic.go
+++ b/pkg/meta/logic.go
@@ -1384,9 +1384,6 @@ func (topo *ClusterSpecification) Endpoints(user string) []*scripts.PDScript {
 		deployDir := clusterutil.Abs(user, spec.DeployDir)
 		// data dir would be empty for components which don't need it
 		dataDir := spec.DataDir
-		if dataDir != "" {
-			dataDir = clusterutil.Abs(user, dataDir)
-		}
 		// log dir will always be with values, but might not used by the component
 		logDir := clusterutil.Abs(user, spec.LogDir)
 
@@ -1410,9 +1407,6 @@ func (topo *ClusterSpecification) AlertManagerEndpoints(user string) []*scripts.
 		deployDir := clusterutil.Abs(user, spec.DeployDir)
 		// data dir would be empty for components which don't need it
 		dataDir := spec.DataDir
-		if dataDir != "" {
-			dataDir = clusterutil.Abs(user, dataDir)
-		}
 		// log dir will always be with values, but might not used by the component
 		logDir := clusterutil.Abs(user, spec.LogDir)
 

--- a/pkg/meta/logic.go
+++ b/pkg/meta/logic.go
@@ -243,13 +243,18 @@ func (i *instance) GetSSHPort() int {
 }
 
 func (i *instance) DeployDir() string {
-	return reflect.ValueOf(i.InstanceSpec).FieldByName("DeployDir").Interface().(string)
+	return reflect.ValueOf(i.InstanceSpec).FieldByName("DeployDir").String()
 }
 
 func (i *instance) DataDir() string {
 	dataDir := reflect.ValueOf(i.InstanceSpec).FieldByName("DataDir")
 	if !dataDir.IsValid() {
 		return ""
+	}
+
+	// the default data_dir is relative to deploy_dir
+	if dataDir.String() != "" && !strings.HasPrefix(dataDir.String(), "/") {
+		return filepath.Join(i.DeployDir(), dataDir.String())
 	}
 
 	return dataDir.String()

--- a/pkg/meta/logic_dm.go
+++ b/pkg/meta/logic_dm.go
@@ -482,6 +482,10 @@ func (topo *DMSpecification) Endpoints(user string) []*scripts.DMMasterScript {
 		deployDir := clusterutil.Abs(user, spec.DeployDir)
 		// data dir would be empty for components which don't need it
 		dataDir := spec.DataDir
+		// the default data_dir is relative to deploy_dir
+		if dataDir != "" && !strings.HasPrefix(dataDir, "/") {
+			dataDir = filepath.Join(deployDir, dataDir)
+		}
 		// log dir will always be with values, but might not used by the component
 		logDir := clusterutil.Abs(user, spec.LogDir)
 

--- a/pkg/meta/logic_dm.go
+++ b/pkg/meta/logic_dm.go
@@ -483,7 +483,7 @@ func (topo *DMSpecification) Endpoints(user string) []*scripts.DMMasterScript {
 		// data dir would be empty for components which don't need it
 		dataDir := spec.DataDir
 		if dataDir != "" {
-			clusterutil.Abs(user, dataDir)
+			dataDir = clusterutil.Abs(user, dataDir)
 		}
 		// log dir will always be with values, but might not used by the component
 		logDir := clusterutil.Abs(user, spec.LogDir)

--- a/pkg/meta/logic_dm.go
+++ b/pkg/meta/logic_dm.go
@@ -482,9 +482,6 @@ func (topo *DMSpecification) Endpoints(user string) []*scripts.DMMasterScript {
 		deployDir := clusterutil.Abs(user, spec.DeployDir)
 		// data dir would be empty for components which don't need it
 		dataDir := spec.DataDir
-		if dataDir != "" {
-			dataDir = clusterutil.Abs(user, dataDir)
-		}
 		// log dir will always be with values, but might not used by the component
 		logDir := clusterutil.Abs(user, spec.LogDir)
 

--- a/pkg/meta/topology.go
+++ b/pkg/meta/topology.go
@@ -757,6 +757,11 @@ func (topo *TopologySpecification) dirConflictsDetect() error {
 						host: host,
 						dir:  compSpec.Field(j).String(),
 					}
+					// data_dir is relative to deploy_dir by default, so they can be with
+					// same (sub) paths as long as the deploy_dirs are different
+					if item.dir != "" && !strings.HasPrefix(item.dir, "/") {
+						continue
+					}
 					// `yaml:"data_dir,omitempty"`
 					tp := strings.Split(compSpec.Type().Field(j).Tag.Get("yaml"), ",")[0]
 					prev, exist := dirStats[item]

--- a/pkg/meta/topology.go
+++ b/pkg/meta/topology.go
@@ -898,7 +898,28 @@ func setCustomDefaults(globalOptions *GlobalOptions, field reflect.Value) error 
 			clientPort := field.FieldByName("ClientPort").Int()
 			field.Field(j).Set(reflect.ValueOf(fmt.Sprintf("pd-%s-%d", host, clientPort)))
 		case "DataDir":
-			setDefaultDir(globalOptions.DataDir, field.Interface().(InstanceSpec).Role(), getPort(field), field.Field(j))
+			dataDir := field.Field(j).String()
+			if dataDir != "" { // already have a value, skip filling default values
+				continue
+			}
+			// If the data dir in global options is an obsolute path, it appends to
+			// the global and has a comp-port sub directory
+			if strings.HasPrefix(globalOptions.DataDir, "/") {
+				field.Field(j).Set(reflect.ValueOf(filepath.Join(
+					globalOptions.DataDir,
+					fmt.Sprintf("%s-%s", field.Interface().(InstanceSpec).Role(), getPort(field)),
+				)))
+				continue
+			}
+			// If the data dir in global options is empty or a relative path, keep it be relative
+			// Our run_*.sh start scripts are run inside deploy_path, so the final location
+			// will be deploy_path/global.data_dir
+			// (the default value of global.data_dir is "data")
+			if globalOptions.DataDir == "" {
+				field.Field(j).Set(reflect.ValueOf("data"))
+			} else {
+				field.Field(j).Set(reflect.ValueOf(globalOptions.DataDir))
+			}
 		case "DeployDir":
 			setDefaultDir(globalOptions.DeployDir, field.Interface().(InstanceSpec).Role(), getPort(field), field.Field(j))
 		case "LogDir":

--- a/pkg/meta/topology_test.go
+++ b/pkg/meta/topology_test.go
@@ -86,13 +86,28 @@ global:
   data_dir: "test-data" 
 tidb_servers:
   - host: 172.16.5.138
-    deploy_dir: "test-1"
+    deploy_dir: "/test-1"
+pd_servers:
+  - host: 172.16.5.138
+    data_dir: "/test-1"
+`), &topo)
+	c.Assert(err, NotNil)
+	c.Assert(err.Error(), Equals, "directory '/test-1' conflicts between 'tidb_servers:172.16.5.138.deploy_dir' and 'pd_servers:172.16.5.138.data_dir'")
+
+	err = yaml.Unmarshal([]byte(`
+global:
+  user: "test1"
+  ssh_port: 220
+  deploy_dir: "test-deploy"
+  data_dir: "/test-data" 
+tikv_servers:
+  - host: 172.16.5.138
+    data_dir: "test-1"
 pd_servers:
   - host: 172.16.5.138
     data_dir: "test-1"
 `), &topo)
-	c.Assert(err, NotNil)
-	c.Assert(err.Error(), Equals, "directory 'test-1' conflicts between 'tidb_servers:172.16.5.138.deploy_dir' and 'pd_servers:172.16.5.138.data_dir'")
+	c.Assert(err, IsNil)
 }
 
 func (s *metaSuite) TestPortConflicts(c *C) {

--- a/pkg/operation/check.go
+++ b/pkg/operation/check.go
@@ -17,12 +17,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
 
 	"github.com/AstroProfundis/sysinfo"
-	"github.com/pingcap-incubator/tiup-cluster/pkg/clusterutil"
 	"github.com/pingcap-incubator/tiup-cluster/pkg/executor"
 	"github.com/pingcap-incubator/tiup-cluster/pkg/log"
 	"github.com/pingcap-incubator/tiup-cluster/pkg/meta"
@@ -500,7 +500,9 @@ func CheckPartitions(opt *CheckOptions, host string, topo *meta.TopologySpecific
 		if dataDir == "" {
 			return
 		}
-		dataDir = clusterutil.Abs(topo.GlobalOptions.User, dataDir)
+		if !strings.HasPrefix(dataDir, "/") {
+			dataDir = filepath.Join(inst.DeployDir(), dataDir)
+		}
 
 		blk := getDisk(parts, dataDir)
 		if blk == nil {

--- a/pkg/operation/check.go
+++ b/pkg/operation/check.go
@@ -17,12 +17,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
-	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
 
 	"github.com/AstroProfundis/sysinfo"
+	"github.com/pingcap-incubator/tiup-cluster/pkg/clusterutil"
 	"github.com/pingcap-incubator/tiup-cluster/pkg/executor"
 	"github.com/pingcap-incubator/tiup-cluster/pkg/log"
 	"github.com/pingcap-incubator/tiup-cluster/pkg/meta"
@@ -496,12 +496,9 @@ func CheckPartitions(opt *CheckOptions, host string, topo *meta.TopologySpecific
 		if inst.GetHost() != host {
 			return
 		}
-		dataDir := inst.DataDir()
+		dataDir := clusterutil.Abs(topo.GlobalOptions.User, inst.DataDir())
 		if dataDir == "" {
 			return
-		}
-		if !strings.HasPrefix(dataDir, "/") {
-			dataDir = filepath.Join(inst.DeployDir(), dataDir)
 		}
 
 		blk := getDisk(parts, dataDir)


### PR DESCRIPTION
The `data_dir`s are not properly set to expanded full path, leading to incorrect start scripts on instances, those data files are actually stored inside `deploy_dir`.

This was introduced in #194 and as changing the behavior may be incompatible with clusters deployed by legacy releases, we change the logic to let the default data dirs remain in `deploy_dir`. (This is also the original behavior of `tidb-ansible`)

This PR also adds a version string of ourself to the `meta.yaml` file (and update every time the file is updated), it's only for debugging reference and not used by any code at present.