### PR TITLE
Add support for hybrid os/arch

### DIFF
--- a/cmd/cluster/command/check.go
+++ b/cmd/cluster/command/check.go
@@ -101,11 +101,26 @@ func checkSystemInfo(s *cliutil.SSHConnectionProps, topo *meta.TopologySpecifica
 		checkSysTasks []*task.StepDisplay
 		cleanTasks    []*task.StepDisplay
 		applyFixTasks []*task.StepDisplay
+		downloadTasks []*task.StepDisplay
 	)
 	insightVer := meta.ComponentVersion(meta.ComponentCheckCollector, "")
 
-	uniqueHosts := map[string]int{} // host -> ssh-port
+	uniqueHosts := map[string]int{}             // host -> ssh-port
+	uniqueArchList := make(map[string]struct{}) // map["os-arch"]{}
 	topo.IterInstance(func(inst meta.Instance) {
+		archKey := fmt.Sprintf("%s-%s", inst.OS(), inst.Arch())
+		if _, found := uniqueArchList[archKey]; !found {
+			uniqueArchList[archKey] = struct{}{}
+			t0 := task.NewBuilder().
+				Download(
+					meta.ComponentCheckCollector,
+					inst.OS(),
+					inst.Arch(),
+					insightVer,
+				).
+				BuildAsStep(fmt.Sprintf("  - Downloading check tools for %s/%s", inst.OS(), inst.Arch()))
+			downloadTasks = append(downloadTasks, t0)
+		}
 		if _, found := uniqueHosts[inst.GetHost()]; !found {
 			uniqueHosts[inst.GetHost()] = inst.GetSSHPort()
 
@@ -228,7 +243,7 @@ func checkSystemInfo(s *cliutil.SSHConnectionProps, topo *meta.TopologySpecifica
 	})
 
 	t := task.NewBuilder().
-		Download(meta.ComponentCheckCollector, insightVer).
+		ParallelStep("+ Download necessary tools", downloadTasks...).
 		ParallelStep("+ Collect basic system information", collectTasks...).
 		ParallelStep("+ Check system requirements", checkSysTasks...).
 		ParallelStep("+ Cleanup check files", cleanTasks...).

--- a/cmd/cluster/command/check.go
+++ b/cmd/cluster/command/check.go
@@ -136,7 +136,14 @@ func checkSystemInfo(s *cliutil.SSHConnectionProps, topo *meta.TopologySpecifica
 					gOpt.SSHTimeout,
 				).
 				Mkdir(opt.user, inst.GetHost(), filepath.Join(task.CheckToolsPathDir, "bin")).
-				CopyComponent(meta.ComponentCheckCollector, insightVer, inst.GetHost(), task.CheckToolsPathDir).
+				CopyComponent(
+					meta.ComponentCheckCollector,
+					inst.OS(),
+					inst.Arch(),
+					insightVer,
+					inst.GetHost(),
+					task.CheckToolsPathDir,
+				).
 				Shell(
 					inst.GetHost(),
 					filepath.Join(task.CheckToolsPathDir, "bin", "insight"),

--- a/cmd/cluster/command/deploy.go
+++ b/cmd/cluster/command/deploy.go
@@ -323,16 +323,16 @@ func buildMonitoredDeployTask(
 	monitoredOptions meta.MonitoredOptions,
 	version string,
 ) (downloadCompTasks []*task.StepDisplay, deployCompTasks []*task.StepDisplay) {
-	uniqueOsArch := make(map[string]struct{}) // os-arch -> {}
+	uniqueCompOSArch := make(map[string]struct{}) // comp-os-arch -> {}
 	// monitoring agents
 	for _, comp := range []string{meta.ComponentNodeExporter, meta.ComponentBlackboxExporter} {
 		version := meta.ComponentVersion(comp, version)
 
 		for host, info := range uniqueHosts {
 			// populate unique os/arch set
-			key := fmt.Sprintf("%s-%s", info.os, info.arch)
-			if _, found := uniqueOsArch[key]; !found {
-				uniqueOsArch[key] = struct{}{}
+			key := fmt.Sprintf("%s-%s-%s", comp, info.os, info.arch)
+			if _, found := uniqueCompOSArch[key]; !found {
+				uniqueCompOSArch[key] = struct{}{}
 				downloadCompTasks = append(downloadCompTasks, task.NewBuilder().
 					Download(comp, info.os, info.arch, version).
 					BuildAsStep(fmt.Sprintf("  - Download %s:%s", comp, version)))

--- a/cmd/cluster/command/deploy.go
+++ b/cmd/cluster/command/deploy.go
@@ -93,7 +93,7 @@ func confirmTopology(clusterName, version string, topo *meta.ClusterSpecificatio
 
 	clusterTable := [][]string{
 		// Header
-		{"Type", "Host", "Ports", "Directories"},
+		{"Type", "Host", "Ports", "OS/Arch", "Directories"},
 	}
 
 	topo.IterInstance(func(instance meta.Instance) {
@@ -105,6 +105,7 @@ func confirmTopology(clusterName, version string, topo *meta.ClusterSpecificatio
 			comp,
 			instance.GetHost(),
 			utils.JoinInt(instance.UsedPorts(), "/"),
+			cliutil.OsArch(instance.OS(), instance.Arch()),
 			strings.Join(instance.UsedDirs(), ","),
 		})
 	})
@@ -335,7 +336,7 @@ func buildMonitoredDeployTask(
 				uniqueCompOSArch[key] = struct{}{}
 				downloadCompTasks = append(downloadCompTasks, task.NewBuilder().
 					Download(comp, info.os, info.arch, version).
-					BuildAsStep(fmt.Sprintf("  - Download %s:%s", comp, version)))
+					BuildAsStep(fmt.Sprintf("  - Download %s:%s (%s/%s)", comp, version, info.os, info.arch)))
 			}
 
 			deployDir := clusterutil.Abs(globalOptions.User, monitoredOptions.DeployDir)

--- a/cmd/cluster/command/deploy.go
+++ b/cmd/cluster/command/deploy.go
@@ -247,7 +247,14 @@ func deploy(clusterName, clusterVersion, topoFile string, opt deployOptions) err
 				filepath.Join(deployDir, "bin"),
 				filepath.Join(deployDir, "conf"),
 				filepath.Join(deployDir, "scripts")).
-			CopyComponent(inst.ComponentName(), version, inst.GetHost(), deployDir).
+			CopyComponent(
+				inst.ComponentName(),
+				inst.OS(),
+				inst.Arch(),
+				version,
+				inst.GetHost(),
+				deployDir,
+			).
 			InitConfig(
 				clusterName,
 				clusterVersion,
@@ -323,7 +330,7 @@ func buildMonitoredDeployTask(
 
 		for host, info := range uniqueHosts {
 			// populate unique os/arch set
-			key := fmt.Sprintf("%s/%s", info.os, info.arch)
+			key := fmt.Sprintf("%s-%s", info.os, info.arch)
 			if _, found := uniqueOsArch[key]; !found {
 				uniqueOsArch[key] = struct{}{}
 				downloadCompTasks = append(downloadCompTasks, task.NewBuilder().
@@ -349,7 +356,14 @@ func buildMonitoredDeployTask(
 					filepath.Join(deployDir, "bin"),
 					filepath.Join(deployDir, "conf"),
 					filepath.Join(deployDir, "scripts")).
-				CopyComponent(comp, version, host, deployDir).
+				CopyComponent(
+					comp,
+					info.os,
+					info.arch,
+					version,
+					host,
+					deployDir,
+				).
 				MonitoredConfig(
 					clusterName,
 					comp,

--- a/cmd/cluster/command/deploy.go
+++ b/cmd/cluster/command/deploy.go
@@ -303,7 +303,7 @@ func buildMonitoredDeployTask(
 	for _, comp := range []string{meta.ComponentNodeExporter, meta.ComponentBlackboxExporter} {
 		version := meta.ComponentVersion(comp, version)
 		t := task.NewBuilder().
-			Download(comp, version).
+			Download(comp, "linux", "amd64", version).
 			BuildAsStep(fmt.Sprintf("  - Download %s:%s", comp, version))
 		downloadCompTasks = append(downloadCompTasks, t)
 

--- a/cmd/cluster/command/display.go
+++ b/cmd/cluster/command/display.go
@@ -133,7 +133,7 @@ func displayClusterTopology(clusterName string, opt *operator.Options) error {
 
 	clusterTable := [][]string{
 		// Header
-		{"ID", "Role", "Host", "Ports", "Status", "Data Dir", "Deploy Dir"},
+		{"ID", "Role", "Host", "Ports", "OS/Arch", "Status", "Data Dir", "Deploy Dir"},
 	}
 
 	ctx := task.NewContext()
@@ -189,6 +189,7 @@ func displayClusterTopology(clusterName string, opt *operator.Options) error {
 				ins.Role(),
 				ins.GetHost(),
 				utils.JoinInt(ins.UsedPorts(), "/"),
+				cliutil.OsArch(ins.OS(), ins.Arch()),
 				formatInstanceStatus(status),
 				dataDir,
 				deployDir,

--- a/cmd/cluster/command/reload.go
+++ b/cmd/cluster/command/reload.go
@@ -99,7 +99,8 @@ func buildReloadTask(
 			switch compName := inst.ComponentName(); compName {
 			case meta.ComponentGrafana, meta.ComponentPrometheus, meta.ComponentAlertManager:
 				version := meta.ComponentVersion(compName, metadata.Version)
-				tb.Download(compName, version).CopyComponent(compName, version, inst.GetHost(), deployDir)
+				tb.Download(compName, inst.OS(), inst.Arch(), version).
+					CopyComponent(compName, version, inst.GetHost(), deployDir)
 			}
 		}
 

--- a/cmd/cluster/command/reload.go
+++ b/cmd/cluster/command/reload.go
@@ -100,7 +100,7 @@ func buildReloadTask(
 			case meta.ComponentGrafana, meta.ComponentPrometheus, meta.ComponentAlertManager:
 				version := meta.ComponentVersion(compName, metadata.Version)
 				tb.Download(compName, inst.OS(), inst.Arch(), version).
-					CopyComponent(compName, version, inst.GetHost(), deployDir)
+					CopyComponent(compName, inst.OS(), inst.Arch(), version, inst.GetHost(), deployDir)
 			}
 		}
 

--- a/cmd/cluster/command/scale_in.go
+++ b/cmd/cluster/command/scale_in.go
@@ -96,7 +96,7 @@ func scaleIn(clusterName string, options operator.Options) error {
 				case meta.ComponentGrafana, meta.ComponentPrometheus, meta.ComponentAlertManager:
 					version := meta.ComponentVersion(compName, metadata.Version)
 					tb.Download(compName, instance.OS(), instance.Arch(), version).
-						CopyComponent(compName, version, instance.GetHost(), deployDir)
+						CopyComponent(compName, instance.OS(), instance.Arch(), version, instance.GetHost(), deployDir)
 				}
 			}
 

--- a/cmd/cluster/command/scale_in.go
+++ b/cmd/cluster/command/scale_in.go
@@ -95,7 +95,8 @@ func scaleIn(clusterName string, options operator.Options) error {
 				switch compName := instance.ComponentName(); compName {
 				case meta.ComponentGrafana, meta.ComponentPrometheus, meta.ComponentAlertManager:
 					version := meta.ComponentVersion(compName, metadata.Version)
-					tb.Download(compName, version).CopyComponent(compName, version, instance.GetHost(), deployDir)
+					tb.Download(compName, instance.OS(), instance.Arch(), version).
+						CopyComponent(compName, version, instance.GetHost(), deployDir)
 				}
 			}
 

--- a/cmd/cluster/command/scale_out.go
+++ b/cmd/cluster/command/scale_out.go
@@ -262,7 +262,8 @@ func buildScaleOutTask(
 			switch compName := inst.ComponentName(); compName {
 			case meta.ComponentGrafana, meta.ComponentPrometheus, meta.ComponentAlertManager:
 				version := meta.ComponentVersion(compName, metadata.Version)
-				tb.Download(compName, version).CopyComponent(compName, version, inst.GetHost(), deployDir)
+				tb.Download(compName, inst.OS(), inst.Arch(), version).
+					CopyComponent(compName, version, inst.GetHost(), deployDir)
 			}
 		}
 

--- a/cmd/cluster/command/scale_out.go
+++ b/cmd/cluster/command/scale_out.go
@@ -165,12 +165,8 @@ func buildScaleOutTask(
 		initializedHosts.Insert(instance.GetHost())
 	})
 	// uninitializedHosts are hosts which haven't been initialized yet
-	uninitializedHosts := make(map[string]struct {
-		ssh  int
-		os   string
-		arch string
-	}) // host -> ssh-port, os, arch
-	var iterErr error // error when itering over instances
+	uninitializedHosts := make(map[string]hostInfo) // host -> ssh-port, os, arch
+	var iterErr error                               // error when itering over instances
 	iterErr = nil
 	newPart.IterInstance(func(instance meta.Instance) {
 		if host := instance.GetHost(); !initializedHosts.Exist(host) {
@@ -183,11 +179,7 @@ func buildScaleOutTask(
 				return // skip the host to avoid issues
 			}
 
-			uninitializedHosts[host] = struct {
-				ssh  int
-				os   string
-				arch string
-			}{
+			uninitializedHosts[host] = hostInfo{
 				ssh:  instance.GetSSHPort(),
 				os:   instance.OS(),
 				arch: instance.Arch(),

--- a/cmd/cluster/command/scale_out.go
+++ b/cmd/cluster/command/scale_out.go
@@ -165,8 +165,12 @@ func buildScaleOutTask(
 		initializedHosts.Insert(instance.GetHost())
 	})
 	// uninitializedHosts are hosts which haven't been initialized yet
-	uninitializedHosts := map[string]int{} // host -> ssh-port
-	var iterErr error                      // error when itering over instances
+	uninitializedHosts := make(map[string]struct {
+		ssh  int
+		os   string
+		arch string
+	}) // host -> ssh-port, os, arch
+	var iterErr error // error when itering over instances
 	iterErr = nil
 	newPart.IterInstance(func(instance meta.Instance) {
 		if host := instance.GetHost(); !initializedHosts.Exist(host) {
@@ -179,7 +183,15 @@ func buildScaleOutTask(
 				return // skip the host to avoid issues
 			}
 
-			uninitializedHosts[host] = instance.GetSSHPort()
+			uninitializedHosts[host] = struct {
+				ssh  int
+				os   string
+				arch string
+			}{
+				ssh:  instance.GetSSHPort(),
+				os:   instance.OS(),
+				arch: instance.Arch(),
+			}
 
 			var dirs []string
 			globalOptions := metadata.Topology.GlobalOptions

--- a/cmd/cluster/command/scale_out.go
+++ b/cmd/cluster/command/scale_out.go
@@ -245,7 +245,7 @@ func buildScaleOutTask(
 		if patchedComponents.Exist(inst.ComponentName()) {
 			tb.InstallPackage(meta.ClusterPath(clusterName, meta.PatchDirName, inst.ComponentName()+".tar.gz"), inst.GetHost(), deployDir)
 		} else {
-			tb.CopyComponent(inst.ComponentName(), version, inst.GetHost(), deployDir)
+			tb.CopyComponent(inst.ComponentName(), inst.OS(), inst.Arch(), version, inst.GetHost(), deployDir)
 		}
 		t := tb.ScaleConfig(clusterName,
 			metadata.Version,
@@ -275,7 +275,7 @@ func buildScaleOutTask(
 			case meta.ComponentGrafana, meta.ComponentPrometheus, meta.ComponentAlertManager:
 				version := meta.ComponentVersion(compName, metadata.Version)
 				tb.Download(compName, inst.OS(), inst.Arch(), version).
-					CopyComponent(compName, version, inst.GetHost(), deployDir)
+					CopyComponent(compName, inst.OS(), inst.Arch(), version, inst.GetHost(), deployDir)
 			}
 		}
 

--- a/cmd/cluster/command/upgrade.go
+++ b/cmd/cluster/command/upgrade.go
@@ -117,10 +117,10 @@ func upgrade(clusterName, clusterVersion string, opt operator.Options) error {
 			if inst.IsImported() {
 				switch inst.ComponentName() {
 				case meta.ComponentPrometheus, meta.ComponentGrafana, meta.ComponentAlertManager:
-					tb.CopyComponent(inst.ComponentName(), version, inst.GetHost(), deployDir)
+					tb.CopyComponent(inst.ComponentName(), inst.OS(), inst.Arch(), version, inst.GetHost(), deployDir)
 				default:
 					tb.BackupComponent(inst.ComponentName(), metadata.Version, inst.GetHost(), deployDir).
-						CopyComponent(inst.ComponentName(), version, inst.GetHost(), deployDir)
+						CopyComponent(inst.ComponentName(), inst.OS(), inst.Arch(), version, inst.GetHost(), deployDir)
 				}
 				tb.InitConfig(
 					clusterName,
@@ -136,7 +136,7 @@ func upgrade(clusterName, clusterVersion string, opt operator.Options) error {
 				)
 			} else {
 				tb.BackupComponent(inst.ComponentName(), metadata.Version, inst.GetHost(), deployDir).
-					CopyComponent(inst.ComponentName(), version, inst.GetHost(), deployDir)
+					CopyComponent(inst.ComponentName(), inst.OS(), inst.Arch(), version, inst.GetHost(), deployDir)
 			}
 			copyCompTasks = append(copyCompTasks, tb.Build())
 		}

--- a/cmd/cluster/command/upgrade.go
+++ b/cmd/cluster/command/upgrade.go
@@ -14,6 +14,7 @@
 package command
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/joomcode/errorx"
@@ -79,7 +80,7 @@ func upgrade(clusterName, clusterVersion string, opt operator.Options) error {
 		downloadCompTasks []task.Task // tasks which are used to download components
 		copyCompTasks     []task.Task // tasks which are used to copy components to remote host
 
-		uniqueComps = map[componentInfo]struct{}{}
+		uniqueComps = map[string]struct{}{}
 	)
 
 	if err := versionCompare(metadata.Version, clusterVersion); err != nil {
@@ -98,8 +99,9 @@ func upgrade(clusterName, clusterVersion string, opt operator.Options) error {
 			}
 
 			// Download component from repository
-			if _, found := uniqueComps[compInfo]; !found {
-				uniqueComps[compInfo] = struct{}{}
+			key := fmt.Sprintf("%s-%s-%s-%s", compInfo.component, compInfo.version, inst.OS(), inst.Arch())
+			if _, found := uniqueComps[key]; !found {
+				uniqueComps[key] = struct{}{}
 				t := task.NewBuilder().
 					Download(inst.ComponentName(), inst.OS(), inst.Arch(), version).
 					Build()

--- a/cmd/cluster/command/upgrade.go
+++ b/cmd/cluster/command/upgrade.go
@@ -101,7 +101,7 @@ func upgrade(clusterName, clusterVersion string, opt operator.Options) error {
 			if _, found := uniqueComps[compInfo]; !found {
 				uniqueComps[compInfo] = struct{}{}
 				t := task.NewBuilder().
-					Download(inst.ComponentName(), version).
+					Download(inst.ComponentName(), inst.OS(), inst.Arch(), version).
 					Build()
 				downloadCompTasks = append(downloadCompTasks, t)
 			}

--- a/cmd/dm/command/deploy.go
+++ b/cmd/dm/command/deploy.go
@@ -214,7 +214,7 @@ func deploy(clusterName, clusterVersion, topoFile string, opt deployOptions) err
 				filepath.Join(deployDir, "bin"),
 				filepath.Join(deployDir, "conf"),
 				filepath.Join(deployDir, "scripts")).
-			CopyComponent(inst.ComponentName(), version, inst.GetHost(), deployDir).
+			CopyComponent(inst.ComponentName(), inst.OS(), inst.Arch(), version, inst.GetHost(), deployDir).
 			InitConfig(
 				clusterName,
 				clusterVersion,

--- a/pkg/cliutil/tui.go
+++ b/pkg/cliutil/tui.go
@@ -100,3 +100,19 @@ func PromptForPassword(format string, a ...interface{}) string {
 	}
 	return strings.TrimSpace(strings.Trim(string(input), "\n"))
 }
+
+// OsArch builds an "os/arch" string from input, it converts some similar strings
+// to different words to avoid misreading when displaying in terminal
+func OsArch(os, arch string) string {
+	osFmt := os
+	archFmt := arch
+
+	switch arch {
+	case "amd64":
+		archFmt = "x86_64"
+	case "arm64":
+		archFmt = "aarch64"
+	}
+
+	return fmt.Sprintf("%s/%s", osFmt, archFmt)
+}

--- a/pkg/meta/logic.go
+++ b/pkg/meta/logic.go
@@ -82,6 +82,8 @@ type Instance interface {
 	Status(pdList ...string) string
 	DataDir() string
 	LogDir() string
+	OS() string // only linux supported now
+	Arch() string
 }
 
 // Specification represents the topology of cluster/dm
@@ -261,6 +263,14 @@ func (i *instance) DataDir() string {
 	}
 
 	return dataDir.String()
+}
+
+func (i *instance) OS() string {
+	return reflect.ValueOf(i.InstanceSpec).FieldByName("OS").Interface().(string)
+}
+
+func (i *instance) Arch() string {
+	return reflect.ValueOf(i.InstanceSpec).FieldByName("Arch").Interface().(string)
 }
 
 // MergeResourceControl merge the rhs into lhs and overwrite rhs if lhs has value for same field

--- a/pkg/meta/logic_dm.go
+++ b/pkg/meta/logic_dm.go
@@ -162,6 +162,14 @@ func (i *dmInstance) LogDir() string {
 	return logDir
 }
 
+func (i *dmInstance) OS() string {
+	return reflect.ValueOf(i.InstanceSpec).FieldByName("OS").Interface().(string)
+}
+
+func (i *dmInstance) Arch() string {
+	return reflect.ValueOf(i.InstanceSpec).FieldByName("Arch").Interface().(string)
+}
+
 func (i *dmInstance) GetPort() int {
 	return i.port
 }

--- a/pkg/meta/topology.go
+++ b/pkg/meta/topology.go
@@ -957,9 +957,14 @@ func setCustomDefaults(globalOptions *GlobalOptions, field reflect.Value) error 
 			if field.Field(j).String() == "" {
 				field.Field(j).Set(reflect.ValueOf(globalOptions.Arch))
 			}
+
+			switch strings.ToLower(field.Field(j).String()) {
 			// replace "x86_64" with amd64, they are the same in our repo
-			if strings.ToLower(field.Field(j).String()) == "x86_64" {
+			case "x86_64":
 				field.Field(j).Set(reflect.ValueOf("amd64"))
+			// replace "aarch64" with arm64
+			case "aarch64":
+				field.Field(j).Set(reflect.ValueOf("arm64"))
 			}
 		case "OS":
 			if field.Field(j).String() == "" {

--- a/pkg/meta/topology.go
+++ b/pkg/meta/topology.go
@@ -65,8 +65,8 @@ type (
 		DataDir         string          `yaml:"data_dir,omitempty" default:"data"`
 		LogDir          string          `yaml:"log_dir,omitempty"`
 		ResourceControl ResourceControl `yaml:"resource_control,omitempty"`
-		OS              string          `yaml:"os,omitempty"`
-		Arch            string          `yaml:"arch,omitempty"`
+		OS              string          `yaml:"os,omitempty" default:"linux"`
+		Arch            string          `yaml:"arch,omitempty" default:"arm64"`
 	}
 
 	// MonitoredOptions represents the monitored node configuration
@@ -133,8 +133,8 @@ type TiDBSpec struct {
 	NumaNode        string                 `yaml:"numa_node,omitempty"`
 	Config          map[string]interface{} `yaml:"config,omitempty"`
 	ResourceControl ResourceControl        `yaml:"resource_control,omitempty"`
-	Arch            string                 `yaml:"arch,omitempty" default:"amd64"`
-	OS              string                 `yaml:"os,omitempty" default:"linux"`
+	Arch            string                 `yaml:"arch,omitempty"`
+	OS              string                 `yaml:"os,omitempty"`
 }
 
 // statusByURL queries current status of the instance by http status api.
@@ -193,8 +193,8 @@ type TiKVSpec struct {
 	NumaNode        string                 `yaml:"numa_node,omitempty"`
 	Config          map[string]interface{} `yaml:"config,omitempty"`
 	ResourceControl ResourceControl        `yaml:"resource_control,omitempty"`
-	Arch            string                 `yaml:"arch,omitempty" default:"amd64"`
-	OS              string                 `yaml:"os,omitempty" default:"linux"`
+	Arch            string                 `yaml:"arch,omitempty"`
+	OS              string                 `yaml:"os,omitempty"`
 }
 
 // Status queries current status of the instance
@@ -265,8 +265,8 @@ type PDSpec struct {
 	NumaNode        string                 `yaml:"numa_node,omitempty"`
 	Config          map[string]interface{} `yaml:"config,omitempty"`
 	ResourceControl ResourceControl        `yaml:"resource_control,omitempty"`
-	Arch            string                 `yaml:"arch,omitempty" default:"amd64"`
-	OS              string                 `yaml:"os,omitempty" default:"linux"`
+	Arch            string                 `yaml:"arch,omitempty"`
+	OS              string                 `yaml:"os,omitempty"`
 }
 
 // Status queries current status of the instance
@@ -339,8 +339,8 @@ type TiFlashSpec struct {
 	Config               map[string]interface{} `yaml:"config,omitempty"`
 	LearnerConfig        map[string]interface{} `yaml:"learner_config,omitempty"`
 	ResourceControl      ResourceControl        `yaml:"resource_control,omitempty"`
-	Arch                 string                 `yaml:"arch,omitempty" default:"amd64"`
-	OS                   string                 `yaml:"os,omitempty" default:"linux"`
+	Arch                 string                 `yaml:"arch,omitempty"`
+	OS                   string                 `yaml:"os,omitempty"`
 }
 
 // Status queries current status of the instance
@@ -382,8 +382,8 @@ type PumpSpec struct {
 	NumaNode        string                 `yaml:"numa_node,omitempty"`
 	Config          map[string]interface{} `yaml:"config,omitempty"`
 	ResourceControl ResourceControl        `yaml:"resource_control"`
-	Arch            string                 `yaml:"arch,omitempty" default:"amd64"`
-	OS              string                 `yaml:"os,omitempty" default:"linux"`
+	Arch            string                 `yaml:"arch,omitempty"`
+	OS              string                 `yaml:"os,omitempty"`
 }
 
 // Role returns the component role of the instance
@@ -420,8 +420,8 @@ type DrainerSpec struct {
 	NumaNode        string                 `yaml:"numa_node,omitempty"`
 	Config          map[string]interface{} `yaml:"config,omitempty"`
 	ResourceControl ResourceControl        `yaml:"resource_control,omitempty"`
-	Arch            string                 `yaml:"arch,omitempty" default:"amd64"`
-	OS              string                 `yaml:"os,omitempty" default:"linux"`
+	Arch            string                 `yaml:"arch,omitempty"`
+	OS              string                 `yaml:"os,omitempty"`
 }
 
 // Role returns the component role of the instance
@@ -456,8 +456,8 @@ type CDCSpec struct {
 	NumaNode        string                 `yaml:"numa_node,omitempty"`
 	Config          map[string]interface{} `yaml:"config,omitempty"`
 	ResourceControl ResourceControl        `yaml:"resource_control,omitempty"`
-	Arch            string                 `yaml:"arch,omitempty" default:"amd64"`
-	OS              string                 `yaml:"os,omitempty" default:"linux"`
+	Arch            string                 `yaml:"arch,omitempty"`
+	OS              string                 `yaml:"os,omitempty"`
 }
 
 // Role returns the component role of the instance
@@ -492,8 +492,8 @@ type PrometheusSpec struct {
 	NumaNode        string          `yaml:"numa_node,omitempty"`
 	Retention       string          `yaml:"storage_retention,omitempty"`
 	ResourceControl ResourceControl `yaml:"resource_control,omitempty"`
-	Arch            string          `yaml:"arch,omitempty" default:"amd64"`
-	OS              string          `yaml:"os,omitempty" default:"linux"`
+	Arch            string          `yaml:"arch,omitempty"`
+	OS              string          `yaml:"os,omitempty"`
 }
 
 // Role returns the component role of the instance
@@ -524,8 +524,8 @@ type GrafanaSpec struct {
 	Port            int             `yaml:"port" default:"3000"`
 	DeployDir       string          `yaml:"deploy_dir,omitempty"`
 	ResourceControl ResourceControl `yaml:"resource_control,omitempty"`
-	Arch            string          `yaml:"arch,omitempty" default:"amd64"`
-	OS              string          `yaml:"os,omitempty" default:"linux"`
+	Arch            string          `yaml:"arch,omitempty"`
+	OS              string          `yaml:"os,omitempty"`
 }
 
 // Role returns the component role of the instance
@@ -560,8 +560,8 @@ type AlertManagerSpec struct {
 	LogDir          string          `yaml:"log_dir,omitempty"`
 	NumaNode        string          `yaml:"numa_node,omitempty"`
 	ResourceControl ResourceControl `yaml:"resource_control,omitempty"`
-	Arch            string          `yaml:"arch,omitempty" default:"amd64"`
-	OS              string          `yaml:"os,omitempty" default:"linux"`
+	Arch            string          `yaml:"arch,omitempty"`
+	OS              string          `yaml:"os,omitempty"`
 }
 
 // Role returns the component role of the instance
@@ -591,6 +591,7 @@ func (topo *TopologySpecification) UnmarshalYAML(unmarshal func(interface{}) err
 		return err
 	}
 
+	// set default values from tag
 	if err := defaults.Set(topo); err != nil {
 		return errors.Trace(err)
 	}
@@ -605,6 +606,7 @@ func (topo *TopologySpecification) UnmarshalYAML(unmarshal func(interface{}) err
 			fmt.Sprintf("%s-%d", RoleMonitor, topo.MonitoredOptions.NodeExporterPort))
 	}
 
+	// populate custom default values as needed
 	if err := fillCustomDefaults(&topo.GlobalOptions, topo); err != nil {
 		return err
 	}
@@ -1016,6 +1018,8 @@ func setCustomDefaults(globalOptions *GlobalOptions, field reflect.Value) error 
 				field.Field(j).Set(reflect.ValueOf(globalOptions.LogDir))
 			}
 		case "Arch":
+			// default values of globalOptions are set before fillCustomDefaults in Unmarshal
+			// so the globalOptions.Arch already has its default value set, no need to check again
 			if field.Field(j).String() == "" {
 				field.Field(j).Set(reflect.ValueOf(globalOptions.Arch))
 			}
@@ -1034,6 +1038,7 @@ func setCustomDefaults(globalOptions *GlobalOptions, field reflect.Value) error 
 				field.Field(j).Set(reflect.ValueOf(strings.ToLower(field.Field(j).String())))
 			}
 		case "OS":
+			// default value of globalOptions.OS is already set, same as "Arch"
 			if field.Field(j).String() == "" {
 				field.Field(j).Set(reflect.ValueOf(globalOptions.OS))
 			}

--- a/pkg/meta/topology.go
+++ b/pkg/meta/topology.go
@@ -66,7 +66,7 @@ type (
 		LogDir          string          `yaml:"log_dir,omitempty"`
 		ResourceControl ResourceControl `yaml:"resource_control,omitempty"`
 		OS              string          `yaml:"os,omitempty" default:"linux"`
-		Arch            string          `yaml:"arch,omitempty" default:"arm64"`
+		Arch            string          `yaml:"arch,omitempty" default:"amd64"`
 	}
 
 	// MonitoredOptions represents the monitored node configuration
@@ -671,8 +671,8 @@ func (topo *TopologySpecification) platformConflictsDetect() error {
 			prev, exist := platformStats[host]
 			if exist {
 				if prev.os != stat.os || prev.arch != stat.arch {
-					return errors.Errorf("platform different for '%s' between '%s/%s:%s' and '%s/%s:%s'",
-						host, prev.os, prev.arch, prev.cfg, stat.os, stat.arch, stat.cfg)
+					return errors.Errorf("platform mismatch for '%s' as in '%s:%s/%s' and '%s:%s/%s'",
+						host, prev.cfg, prev.os, prev.arch, stat.cfg, stat.os, stat.arch)
 				}
 			}
 			platformStats[host] = stat

--- a/pkg/meta/topology.go
+++ b/pkg/meta/topology.go
@@ -1028,6 +1028,11 @@ func setCustomDefaults(globalOptions *GlobalOptions, field reflect.Value) error 
 			case "aarch64":
 				field.Field(j).Set(reflect.ValueOf("arm64"))
 			}
+
+			// convert to lower case
+			if field.Field(j).String() != "" {
+				field.Field(j).Set(reflect.ValueOf(strings.ToLower(field.Field(j).String())))
+			}
 		case "OS":
 			if field.Field(j).String() == "" {
 				field.Field(j).Set(reflect.ValueOf(globalOptions.OS))

--- a/pkg/meta/topology.go
+++ b/pkg/meta/topology.go
@@ -65,6 +65,8 @@ type (
 		DataDir         string          `yaml:"data_dir,omitempty" default:"data"`
 		LogDir          string          `yaml:"log_dir,omitempty"`
 		ResourceControl ResourceControl `yaml:"resource_control,omitempty"`
+		OS              string          `yaml:"os,omitempty"`
+		Arch            string          `yaml:"arch,omitempty"`
 	}
 
 	// MonitoredOptions represents the monitored node configuration
@@ -131,6 +133,8 @@ type TiDBSpec struct {
 	NumaNode        string                 `yaml:"numa_node,omitempty"`
 	Config          map[string]interface{} `yaml:"config,omitempty"`
 	ResourceControl ResourceControl        `yaml:"resource_control,omitempty"`
+	Arch            string                 `yaml:"arch,omitempty" default:"amd64"`
+	OS              string                 `yaml:"os,omitempty" default:"linux"`
 }
 
 // statusByURL queries current status of the instance by http status api.
@@ -189,6 +193,8 @@ type TiKVSpec struct {
 	NumaNode        string                 `yaml:"numa_node,omitempty"`
 	Config          map[string]interface{} `yaml:"config,omitempty"`
 	ResourceControl ResourceControl        `yaml:"resource_control,omitempty"`
+	Arch            string                 `yaml:"arch,omitempty" default:"amd64"`
+	OS              string                 `yaml:"os,omitempty" default:"linux"`
 }
 
 // Status queries current status of the instance
@@ -259,6 +265,8 @@ type PDSpec struct {
 	NumaNode        string                 `yaml:"numa_node,omitempty"`
 	Config          map[string]interface{} `yaml:"config,omitempty"`
 	ResourceControl ResourceControl        `yaml:"resource_control,omitempty"`
+	Arch            string                 `yaml:"arch,omitempty" default:"amd64"`
+	OS              string                 `yaml:"os,omitempty" default:"linux"`
 }
 
 // Status queries current status of the instance
@@ -331,6 +339,8 @@ type TiFlashSpec struct {
 	Config               map[string]interface{} `yaml:"config,omitempty"`
 	LearnerConfig        map[string]interface{} `yaml:"learner_config,omitempty"`
 	ResourceControl      ResourceControl        `yaml:"resource_control,omitempty"`
+	Arch                 string                 `yaml:"arch,omitempty" default:"amd64"`
+	OS                   string                 `yaml:"os,omitempty" default:"linux"`
 }
 
 // Status queries current status of the instance
@@ -372,6 +382,8 @@ type PumpSpec struct {
 	NumaNode        string                 `yaml:"numa_node,omitempty"`
 	Config          map[string]interface{} `yaml:"config,omitempty"`
 	ResourceControl ResourceControl        `yaml:"resource_control"`
+	Arch            string                 `yaml:"arch,omitempty" default:"amd64"`
+	OS              string                 `yaml:"os,omitempty" default:"linux"`
 }
 
 // Role returns the component role of the instance
@@ -408,6 +420,8 @@ type DrainerSpec struct {
 	NumaNode        string                 `yaml:"numa_node,omitempty"`
 	Config          map[string]interface{} `yaml:"config,omitempty"`
 	ResourceControl ResourceControl        `yaml:"resource_control,omitempty"`
+	Arch            string                 `yaml:"arch,omitempty" default:"amd64"`
+	OS              string                 `yaml:"os,omitempty" default:"linux"`
 }
 
 // Role returns the component role of the instance
@@ -442,6 +456,8 @@ type CDCSpec struct {
 	NumaNode        string                 `yaml:"numa_node,omitempty"`
 	Config          map[string]interface{} `yaml:"config,omitempty"`
 	ResourceControl ResourceControl        `yaml:"resource_control,omitempty"`
+	Arch            string                 `yaml:"arch,omitempty" default:"amd64"`
+	OS              string                 `yaml:"os,omitempty" default:"linux"`
 }
 
 // Role returns the component role of the instance
@@ -476,6 +492,8 @@ type PrometheusSpec struct {
 	NumaNode        string          `yaml:"numa_node,omitempty"`
 	Retention       string          `yaml:"storage_retention,omitempty"`
 	ResourceControl ResourceControl `yaml:"resource_control,omitempty"`
+	Arch            string          `yaml:"arch,omitempty" default:"amd64"`
+	OS              string          `yaml:"os,omitempty" default:"linux"`
 }
 
 // Role returns the component role of the instance
@@ -506,6 +524,8 @@ type GrafanaSpec struct {
 	Port            int             `yaml:"port" default:"3000"`
 	DeployDir       string          `yaml:"deploy_dir,omitempty"`
 	ResourceControl ResourceControl `yaml:"resource_control,omitempty"`
+	Arch            string          `yaml:"arch,omitempty" default:"amd64"`
+	OS              string          `yaml:"os,omitempty" default:"linux"`
 }
 
 // Role returns the component role of the instance
@@ -540,6 +560,8 @@ type AlertManagerSpec struct {
 	LogDir          string          `yaml:"log_dir,omitempty"`
 	NumaNode        string          `yaml:"numa_node,omitempty"`
 	ResourceControl ResourceControl `yaml:"resource_control,omitempty"`
+	Arch            string          `yaml:"arch,omitempty" default:"amd64"`
+	OS              string          `yaml:"os,omitempty" default:"linux"`
 }
 
 // Role returns the component role of the instance
@@ -930,6 +952,22 @@ func setCustomDefaults(globalOptions *GlobalOptions, field reflect.Value) error 
 		case "LogDir":
 			if field.Field(j).String() == "" && defaults.CanUpdate(field.Field(j).Interface()) {
 				field.Field(j).Set(reflect.ValueOf(globalOptions.LogDir))
+			}
+		case "Arch":
+			if field.Field(j).String() == "" {
+				field.Field(j).Set(reflect.ValueOf(globalOptions.Arch))
+			}
+			// replace "x86_64" with amd64, they are the same in our repo
+			if strings.ToLower(field.Field(j).String()) == "x86_64" {
+				field.Field(j).Set(reflect.ValueOf("amd64"))
+			}
+		case "OS":
+			if field.Field(j).String() == "" {
+				field.Field(j).Set(reflect.ValueOf(globalOptions.OS))
+			}
+			// convert to lower case
+			if field.Field(j).String() != "" {
+				field.Field(j).Set(reflect.ValueOf(strings.ToLower(field.Field(j).String())))
 			}
 		}
 	}

--- a/pkg/meta/topology_dm.go
+++ b/pkg/meta/topology_dm.go
@@ -59,6 +59,8 @@ type MasterSpec struct {
 	Offline   bool                   `yaml:"offline,omitempty"`
 	NumaNode  string                 `yaml:"numa_node,omitempty"`
 	Config    map[string]interface{} `yaml:"config,omitempty"`
+	Arch      string                 `yaml:"arch,omitempty" default:"amd64"`
+	OS        string                 `yaml:"os,omitempty" default:"linux"`
 }
 
 // Status queries current status of the instance
@@ -101,6 +103,8 @@ type WorkerSpec struct {
 	Offline   bool                   `yaml:"offline,omitempty"`
 	NumaNode  string                 `yaml:"numa_node,omitempty"`
 	Config    map[string]interface{} `yaml:"config,omitempty"`
+	Arch      string                 `yaml:"arch,omitempty" default:"amd64"`
+	OS        string                 `yaml:"os,omitempty" default:"linux"`
 }
 
 // Status queries current status of the instance

--- a/pkg/meta/topology_dm_test.go
+++ b/pkg/meta/topology_dm_test.go
@@ -1,0 +1,210 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package meta
+
+import (
+	. "github.com/pingcap/check"
+	"gopkg.in/yaml.v2"
+)
+
+type metaSuiteDM struct {
+}
+
+var _ = Suite(&metaSuiteDM{})
+
+func (s *metaSuiteDM) TestDefaultDataDir(c *C) {
+	// Test with without global DataDir.
+	topo := new(DMTopologySpecification)
+	topo.Masters = append(topo.Masters, MasterSpec{Host: "1.1.1.1", Port: 1111})
+	topo.Workers = append(topo.Workers, WorkerSpec{Host: "1.1.2.1", Port: 2221})
+	data, err := yaml.Marshal(topo)
+	c.Assert(err, IsNil)
+
+	// Check default value.
+	topo = new(DMTopologySpecification)
+	err = yaml.Unmarshal(data, topo)
+	c.Assert(err, IsNil)
+	c.Assert(topo.GlobalOptions.DataDir, Equals, "data")
+	c.Assert(topo.Masters[0].DataDir, Equals, "data")
+	c.Assert(topo.Workers[0].DataDir, Equals, "data")
+
+	// Can keep the default value.
+	data, err = yaml.Marshal(topo)
+	c.Assert(err, IsNil)
+	topo = new(DMTopologySpecification)
+	err = yaml.Unmarshal(data, topo)
+	c.Assert(err, IsNil)
+	c.Assert(topo.GlobalOptions.DataDir, Equals, "data")
+	c.Assert(topo.Masters[0].DataDir, Equals, "data")
+	c.Assert(topo.Workers[0].DataDir, Equals, "data")
+
+	// Test with global DataDir.
+	topo = new(DMTopologySpecification)
+	topo.GlobalOptions.DataDir = "/gloable_data"
+	topo.Masters = append(topo.Masters, MasterSpec{Host: "1.1.1.1", Port: 1111})
+	topo.Masters = append(topo.Masters, MasterSpec{Host: "1.1.1.2", Port: 1112, DataDir: "/my_data"})
+	topo.Workers = append(topo.Workers, WorkerSpec{Host: "1.1.2.1", Port: 2221})
+	topo.Workers = append(topo.Workers, WorkerSpec{Host: "1.1.2.2", Port: 2222, DataDir: "/my_data"})
+	data, err = yaml.Marshal(topo)
+	c.Assert(err, IsNil)
+
+	topo = new(DMTopologySpecification)
+	err = yaml.Unmarshal(data, topo)
+	c.Assert(err, IsNil)
+	c.Assert(topo.GlobalOptions.DataDir, Equals, "/gloable_data")
+	c.Assert(topo.Masters[0].DataDir, Equals, "/gloable_data/dm_master-1111")
+	c.Assert(topo.Masters[1].DataDir, Equals, "/my_data")
+	c.Assert(topo.Workers[0].DataDir, Equals, "/gloable_data/dm_worker-2221")
+	c.Assert(topo.Workers[1].DataDir, Equals, "/my_data")
+}
+
+func (s *metaSuiteDM) TestGlobalOptions(c *C) {
+	topo := DMTopologySpecification{}
+	err := yaml.Unmarshal([]byte(`
+global:
+  user: "test1"
+  ssh_port: 220
+  deploy_dir: "test-deploy"
+  data_dir: "test-data" 
+dm_masters:
+  - host: 172.16.5.138
+    deploy_dir: "master-deploy"
+dm_workers:
+  - host: 172.16.5.53
+    data_dir: "worker-data"
+`), &topo)
+	c.Assert(err, IsNil)
+	c.Assert(topo.GlobalOptions.User, Equals, "test1")
+	c.Assert(topo.GlobalOptions.SSHPort, Equals, 220)
+	c.Assert(topo.Masters[0].SSHPort, Equals, 220)
+	c.Assert(topo.Masters[0].DeployDir, Equals, "master-deploy")
+
+	c.Assert(topo.Workers[0].SSHPort, Equals, 220)
+	c.Assert(topo.Workers[0].DeployDir, Equals, "test-deploy/dm_worker-8262")
+	c.Assert(topo.Workers[0].DataDir, Equals, "worker-data")
+}
+
+func (s *metaSuiteDM) TestDirectoryConflicts(c *C) {
+	topo := DMTopologySpecification{}
+	err := yaml.Unmarshal([]byte(`
+global:
+  user: "test1"
+  ssh_port: 220
+  deploy_dir: "test-deploy"
+  data_dir: "test-data" 
+dm_masters:
+  - host: 172.16.5.138
+    deploy_dir: "/test-1"
+dm_workers:
+  - host: 172.16.5.138
+    data_dir: "/test-1"
+`), &topo)
+	c.Assert(err, NotNil)
+	c.Assert(err.Error(), Equals, "directory '/test-1' conflicts between 'dm_masters:172.16.5.138.deploy_dir' and 'dm_workers:172.16.5.138.data_dir'")
+
+	err = yaml.Unmarshal([]byte(`
+global:
+  user: "test1"
+  ssh_port: 220
+  deploy_dir: "test-deploy"
+  data_dir: "/test-data" 
+dm_masters:
+  - host: 172.16.5.138
+    data_dir: "test-1"
+dm_workers:
+  - host: 172.16.5.138
+    data_dir: "test-1"
+`), &topo)
+	c.Assert(err, IsNil)
+}
+
+func (s *metaSuiteDM) TestPortConflicts(c *C) {
+	topo := DMTopologySpecification{}
+	err := yaml.Unmarshal([]byte(`
+global:
+  user: "test1"
+  ssh_port: 220
+  deploy_dir: "test-deploy"
+  data_dir: "test-data" 
+dm_masters:
+  - host: 172.16.5.138
+    peer_port: 1234
+dm_workers:
+  - host: 172.16.5.138
+    port: 1234
+`), &topo)
+	c.Assert(err, NotNil)
+	c.Assert(err.Error(), Equals, "port '1234' conflicts between 'dm_masters:172.16.5.138.peer_port' and 'dm_workers:172.16.5.138.port'")
+
+	topo = DMTopologySpecification{}
+	err = yaml.Unmarshal([]byte(`
+monitored:
+  node_exporter_port: 1234
+dm_masters:
+  - host: 172.16.5.138
+    port: 1234
+dm_workers:
+  - host: 172.16.5.138
+    status_port: 2345
+`), &topo)
+	c.Assert(err, NotNil)
+	c.Assert(err.Error(), Equals, "port '1234' conflicts between 'dm_masters:172.16.5.138.port' and 'monitored:172.16.5.138.node_exporter_port'")
+
+}
+
+func (s *metaSuiteDM) TestPlatformConflicts(c *C) {
+	// aarch64 and arm64 are equal
+	topo := DMTopologySpecification{}
+	err := yaml.Unmarshal([]byte(`
+global:
+  os: "linux"
+  arch: "aarch64"
+dm_masters:
+  - host: 172.16.5.138
+    arch: "arm64"
+dm_workers:
+  - host: 172.16.5.138
+`), &topo)
+	c.Assert(err, IsNil)
+
+	// different arch defined for the same host
+	topo = DMTopologySpecification{}
+	err = yaml.Unmarshal([]byte(`
+global:
+  os: "linux"
+dm_masters:
+  - host: 172.16.5.138
+    arch: "aarch64"
+dm_workers:
+  - host: 172.16.5.138
+`), &topo)
+	c.Assert(err, NotNil)
+	c.Assert(err.Error(), Equals, "platform mismatch for '172.16.5.138' as in 'dm_masters:linux/arm64' and 'dm_workers:linux/amd64'")
+
+	// different os defined for the same host
+	topo = DMTopologySpecification{}
+	err = yaml.Unmarshal([]byte(`
+global:
+  os: "linux"
+  arch: "aarch64"
+dm_masters:
+  - host: 172.16.5.138
+    os: "darwin"
+dm_workers:
+  - host: 172.16.5.138
+`), &topo)
+	c.Assert(err, NotNil)
+	c.Assert(err.Error(), Equals, "platform mismatch for '172.16.5.138' as in 'dm_masters:darwin/arm64' and 'dm_workers:linux/arm64'")
+
+}

--- a/pkg/task/builder.go
+++ b/pkg/task/builder.go
@@ -109,9 +109,11 @@ func (b *Builder) CopyFile(src, dst, server string, download bool) *Builder {
 }
 
 // Download appends a Downloader task to the current task collection
-func (b *Builder) Download(component string, version repository.Version) *Builder {
+func (b *Builder) Download(component, os, arch string, version repository.Version) *Builder {
 	b.tasks = append(b.tasks, &Downloader{
 		component: component,
+		os:        os,
+		arch:      arch,
 		version:   version,
 	})
 	return b

--- a/pkg/task/builder.go
+++ b/pkg/task/builder.go
@@ -120,9 +120,14 @@ func (b *Builder) Download(component, os, arch string, version repository.Versio
 }
 
 // CopyComponent appends a CopyComponent task to the current task collection
-func (b *Builder) CopyComponent(component string, version repository.Version, dstHost, dstDir string) *Builder {
+func (b *Builder) CopyComponent(component, os, arch string,
+	version repository.Version,
+	dstHost, dstDir string,
+) *Builder {
 	b.tasks = append(b.tasks, &CopyComponent{
 		component: component,
+		os:        os,
+		arch:      arch,
 		version:   version,
 		host:      dstHost,
 		dstDir:    dstDir,

--- a/pkg/task/copy_component.go
+++ b/pkg/task/copy_component.go
@@ -24,6 +24,8 @@ import (
 // to the target directory of path
 type CopyComponent struct {
 	component string
+	os        string
+	arch      string
 	version   repository.Version
 	host      string
 	dstDir    string
@@ -33,7 +35,7 @@ type CopyComponent struct {
 func (c *CopyComponent) Execute(ctx *Context) error {
 	// Copy to remote server
 	resName := fmt.Sprintf("%s-%s", c.component, c.version)
-	fileName := fmt.Sprintf("%s-linux-amd64.tar.gz", resName)
+	fileName := fmt.Sprintf("%s-%s-%s.tar.gz", resName, c.os, c.arch)
 	srcPath := meta.ProfilePath(meta.TiOpsPackageCacheDir, fileName)
 
 	install := &InstallPackage{
@@ -52,5 +54,6 @@ func (c *CopyComponent) Rollback(ctx *Context) error {
 
 // String implements the fmt.Stringer interface
 func (c *CopyComponent) String() string {
-	return fmt.Sprintf("CopyComponent: component=%s, version=%s, remote=%s:%s", c.component, c.version, c.host, c.dstDir)
+	return fmt.Sprintf("CopyComponent: component=%s, version=%s, remote=%s:%s os=%s, arch=%s",
+		c.component, c.version, c.host, c.dstDir, c.os, c.arch)
 }

--- a/pkg/task/download.go
+++ b/pkg/task/download.go
@@ -122,5 +122,6 @@ func (d *Downloader) Rollback(ctx *Context) error {
 
 // String implements the fmt.Stringer interface
 func (d *Downloader) String() string {
-	return fmt.Sprintf("Download: component=%s, version=%s", d.component, d.version)
+	return fmt.Sprintf("Download: component=%s, version=%s, os=%s, arch=%s",
+		d.component, d.version, d.os, d.arch)
 }

--- a/pkg/task/download.go
+++ b/pkg/task/download.go
@@ -72,12 +72,25 @@ func (d *Downloader) Execute(_ *Context) error {
 			return err
 		}
 
+		// validate component and platform info
+		manifest, err := repo.Manifest()
+		if err != nil {
+			return err
+		}
+		compInfo, found := manifest.FindComponent(d.component)
+		if !found {
+			return errors.Errorf("component '%s' not supported", d.component)
+		}
+		if !compInfo.IsSupport(d.os, d.arch) {
+			return errors.Errorf("component '%s' does not support platform %s/%s", d.component, d.os, d.arch)
+		}
+
 		versions, err := repo.ComponentVersions(d.component)
 		if err != nil {
 			return err
 		}
 		if !d.version.IsNightly() && !versions.ContainsVersion(d.version) {
-			return errors.Errorf("component '%s' doesn't contains version '%s'", d.component, d.version)
+			return errors.Errorf("component '%s' does not contain version '%s'", d.component, d.version)
 		}
 
 		err = repo.Mirror().Download(fileName, meta.ProfilePath(meta.TiOpsPackageCacheDir))

--- a/pkg/task/download.go
+++ b/pkg/task/download.go
@@ -29,6 +29,8 @@ import (
 // the repository, there is nothing to do if the specified version exists.
 type Downloader struct {
 	component string
+	os        string
+	arch      string
 	version   repository.Version
 }
 
@@ -42,8 +44,8 @@ func (d *Downloader) Execute(_ *Context) error {
 	}
 
 	resName := fmt.Sprintf("%s-%s", d.component, d.version)
-	fileName := fmt.Sprintf("%s-linux-amd64.tar.gz", resName)
-	sha1File := fmt.Sprintf("%s-linux-amd64.sha1", resName)
+	fileName := fmt.Sprintf("%s-%s-%s.tar.gz", resName, d.os, d.arch)
+	sha1File := fmt.Sprintf("%s-%s-%s.sha1", resName, d.os, d.arch)
 	srcPath := meta.ProfilePath(meta.TiOpsPackageCacheDir, fileName)
 
 	if err := os.MkdirAll(meta.ProfilePath(meta.TiOpsPackageCacheDir), 0755); err != nil {
@@ -62,8 +64,8 @@ func (d *Downloader) Execute(_ *Context) error {
 		defer mirror.Close()
 
 		repo, err := repository.NewRepository(mirror, repository.Options{
-			GOOS:              "linux",
-			GOARCH:            "amd64",
+			GOOS:              d.os,
+			GOARCH:            d.arch,
 			DisableDecompress: true,
 		})
 		if err != nil {

--- a/pkg/task/env_init.go
+++ b/pkg/task/env_init.go
@@ -84,7 +84,7 @@ func (e *EnvInit) execute(ctx *Context) error {
 	//   - sshd started with custom config (other than /etc/ssh/sshd_config)
 	//   - ssh server implementations other than OpenSSH (such as dropbear)
 	sshAuthorizedKeys := defaultSSHAuthorizedKeys
-	cmd = "grep -Ev '^#|^\\s*$' /etc/ssh/sshd_config"
+	cmd = "grep -Ev '^\\s*#|^\\s*$' /etc/ssh/sshd_config"
 	stdout, _, _ := exec.Execute(cmd, true) // error ignored as we have default value
 	for _, line := range strings.Split(string(stdout), "\n") {
 		if !strings.Contains(line, "AuthorizedKeysFile") {


### PR DESCRIPTION
Add `OS` and `Arch` on instance level, thus supporting hybrid cluster with different OS / arch, i.e., mix ARM instances with x86_64 ones in the same cluster.

 - [x] Support multiple os/arch in specs
 - [x] Support downloading of multi-arch packages
 - [x] Support deploying of multi-arch packages
 - [x] Support upgrading of multi-arch clusters
 - [ ] OS / architecture specific configuration changes
      (none as I noticed yet, everything seems to work out of the box)
 - [x] Validate checks for different OS / arch in `check` sub command
 - [x] Validate topology to report conflicts of OS / arch for the same host
 - [x] Manual testing

Also ported some essential unit test cases form `topology_test.go` for DM topology.