### PR TITLE
Backup deploy/{instance}/bin directory instead of binary only

### DIFF
--- a/pkg/task/backup_component.go
+++ b/pkg/task/backup_component.go
@@ -17,9 +17,6 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"github.com/pingcap-incubator/tiup-cluster/pkg/meta"
-	tiupmeta "github.com/pingcap-incubator/tiup/pkg/meta"
-	"github.com/pingcap-incubator/tiup/pkg/repository"
 	"github.com/pingcap/errors"
 )
 
@@ -29,59 +26,22 @@ type BackupComponent struct {
 	component string
 	fromVer   string
 	host      string
-	dstDir    string
-
-	cpFrom string
-	cpTo   string
+	deployDir string
 }
 
 // Execute implements the Task interface
 func (c *BackupComponent) Execute(ctx *Context) error {
-	m, found := ctx.GetManifest(c.component)
-	if !found {
-		manifest, err := tiupmeta.Repository().ComponentVersions(c.component)
-		if err != nil {
-			return err
-		}
-		m = manifest
-		ctx.SetManifest(c.component, m)
-	}
-
 	// Copy to remote server
 	exec, found := ctx.GetExecutor(c.host)
 	if !found {
 		return ErrNoExecutor
 	}
 
-	// backup old version
-	var versionInfo repository.VersionInfo
-	var foundVersion bool
-	fromVer := meta.ComponentVersion(c.component, c.fromVer)
-	for _, vi := range m.Versions {
-		if vi.Version == fromVer {
-			versionInfo = vi
-			foundVersion = true
-			break
-		}
-	}
-	if !fromVer.IsNightly() && !foundVersion {
-		return errors.Errorf("cannot found previous version %v in %s manifest", c.fromVer, c.component)
-	}
-	if fromVer.IsNightly() && m.Nightly == nil {
-		return errors.Errorf("nightly version unsupported for component %s", c.component)
-	}
-	if fromVer.IsNightly() {
-		versionInfo = *m.Nightly
-	}
+	binDir := filepath.Join(c.deployDir, "bin")
 
-	dstDir := filepath.Join(c.dstDir, "bin")
-	dstPathOld := filepath.Join(dstDir, versionInfo.Entry+".old")
-	dstPath := filepath.Join(dstDir, versionInfo.Entry)
-
-	c.cpFrom = dstPath
-	c.cpTo = dstPathOld
-
-	cmd := fmt.Sprintf(`cp %s %s`, dstPath, dstPathOld)
+	// Make upgrade idempotent
+	// The old version has been backup if upgrade abort
+	cmd := fmt.Sprintf(`test -d %[2]s || mv %[1]s %[2]s && mkdir -p %[1]s`, binDir, binDir+".old."+c.fromVer)
 	_, _, err := exec.Execute(cmd, false)
 	if err != nil {
 		return errors.Annotate(err, cmd)
@@ -97,5 +57,5 @@ func (c *BackupComponent) Rollback(ctx *Context) error {
 // String implements the fmt.Stringer interface
 func (c *BackupComponent) String() string {
 	return fmt.Sprintf("BackupComponent: component=%s, currentVersion=%s, remote=%s:%s",
-		c.component, c.fromVer, c.host, c.dstDir)
+		c.component, c.fromVer, c.host, c.deployDir)
 }

--- a/pkg/task/builder.go
+++ b/pkg/task/builder.go
@@ -139,12 +139,12 @@ func (b *Builder) InstallPackage(srcPath, dstHost, dstDir string) *Builder {
 }
 
 // BackupComponent appends a BackupComponent task to the current task collection
-func (b *Builder) BackupComponent(component, fromVer string, dstHost, dstDir string) *Builder {
+func (b *Builder) BackupComponent(component, fromVer string, host, deployDir string) *Builder {
 	b.tasks = append(b.tasks, &BackupComponent{
 		component: component,
 		fromVer:   fromVer,
-		host:      dstHost,
-		dstDir:    dstDir,
+		host:      host,
+		deployDir: deployDir,
 	})
 	return b
 }


### PR DESCRIPTION
Signed-off-by: Lonng <heng@lonng.org>

Currently, we should rely on the previous version manifest when upgrading, it's impossible in some offline environment.

This PR changes the logic of the backup component, will backup `deploy/bin` directory instead of just the binary.