### PR TITLE
cmd: add --wait-timeout to specify timeout for wait operations

### DIFF
--- a/cmd/cluster/command/check.go
+++ b/cmd/cluster/command/check.go
@@ -118,7 +118,7 @@ func checkSystemInfo(s *cliutil.SSHConnectionProps, topo *meta.TopologySpecifica
 					s.Password,
 					s.IdentityFile,
 					s.IdentityFilePassphrase,
-					sshTimeout,
+					gOpt.SSHTimeout,
 				).
 				Mkdir(opt.user, inst.GetHost(), filepath.Join(task.CheckToolsPathDir, "bin")).
 				CopyComponent(meta.ComponentCheckCollector, insightVer, inst.GetHost(), task.CheckToolsPathDir).
@@ -219,7 +219,7 @@ func checkSystemInfo(s *cliutil.SSHConnectionProps, topo *meta.TopologySpecifica
 					s.Password,
 					s.IdentityFile,
 					s.IdentityFilePassphrase,
-					sshTimeout,
+					gOpt.SSHTimeout,
 				).
 				Rmdir(inst.GetHost(), task.CheckToolsPathDir).
 				BuildAsStep(fmt.Sprintf("  - Cleanup check files on %s:%d", inst.GetHost(), inst.GetSSHPort()))
@@ -258,7 +258,7 @@ func checkSystemInfo(s *cliutil.SSHConnectionProps, topo *meta.TopologySpecifica
 				s.Password,
 				s.IdentityFile,
 				s.IdentityFilePassphrase,
-				sshTimeout,
+				gOpt.SSHTimeout,
 			)
 		resLines, err := handleCheckResults(ctx, host, opt, tf)
 		if err != nil {

--- a/cmd/cluster/command/deploy.go
+++ b/cmd/cluster/command/deploy.go
@@ -192,7 +192,7 @@ func deploy(clusterName, clusterVersion, topoFile string, opt deployOptions) err
 					sshConnProps.Password,
 					sshConnProps.IdentityFile,
 					sshConnProps.IdentityFilePassphrase,
-					sshTimeout,
+					gOpt.SSHTimeout,
 				).
 				EnvInit(inst.GetHost(), globalOptions.User).
 				Mkdir(globalOptions.User, inst.GetHost(), dirs...).
@@ -214,7 +214,7 @@ func deploy(clusterName, clusterVersion, topoFile string, opt deployOptions) err
 		logDir := clusterutil.Abs(globalOptions.User, inst.LogDir())
 		// Deploy component
 		t := task.NewBuilder().
-			UserSSH(inst.GetHost(), inst.GetSSHPort(), globalOptions.User, sshTimeout).
+			UserSSH(inst.GetHost(), inst.GetSSHPort(), globalOptions.User, gOpt.SSHTimeout).
 			Mkdir(globalOptions.User, inst.GetHost(),
 				deployDir, dataDir, logDir,
 				filepath.Join(deployDir, "bin"),
@@ -283,7 +283,8 @@ func buildMonitoredDeployTask(
 	uniqueHosts map[string]int, // host -> ssh-port
 	globalOptions meta.GlobalOptions,
 	monitoredOptions meta.MonitoredOptions,
-	version string) (downloadCompTasks []*task.StepDisplay, deployCompTasks []*task.StepDisplay) {
+	version string,
+) (downloadCompTasks []*task.StepDisplay, deployCompTasks []*task.StepDisplay) {
 	for _, comp := range []string{meta.ComponentNodeExporter, meta.ComponentBlackboxExporter} {
 		version := meta.ComponentVersion(comp, version)
 		t := task.NewBuilder().
@@ -304,7 +305,7 @@ func buildMonitoredDeployTask(
 
 			// Deploy component
 			t := task.NewBuilder().
-				UserSSH(host, sshPort, globalOptions.User, sshTimeout).
+				UserSSH(host, sshPort, globalOptions.User, gOpt.SSHTimeout).
 				Mkdir(globalOptions.User, host,
 					deployDir, dataDir, logDir,
 					filepath.Join(deployDir, "bin"),

--- a/cmd/cluster/command/destroy.go
+++ b/cmd/cluster/command/destroy.go
@@ -63,7 +63,7 @@ func newDestroyCmd() *cobra.Command {
 				SSHKeySet(
 					meta.ClusterPath(clusterName, "ssh", "id_rsa"),
 					meta.ClusterPath(clusterName, "ssh", "id_rsa.pub")).
-				ClusterSSH(metadata.Topology, metadata.User, sshTimeout).
+				ClusterSSH(metadata.Topology, metadata.User, gOpt.SSHTimeout).
 				ClusterOperate(metadata.Topology, operator.StopOperation, operator.Options{}).
 				ClusterOperate(metadata.Topology, operator.DestroyOperation, operator.Options{}).
 				Build()

--- a/cmd/cluster/command/display.go
+++ b/cmd/cluster/command/display.go
@@ -34,7 +34,6 @@ import (
 func newDisplayCmd() *cobra.Command {
 	var (
 		clusterName string
-		options     operator.Options
 	)
 	cmd := &cobra.Command{
 		Use:   "display <cluster-name>",
@@ -45,10 +44,10 @@ func newDisplayCmd() *cobra.Command {
 			}
 
 			clusterName = args[0]
-			if err := displayClusterMeta(clusterName, &options); err != nil {
+			if err := displayClusterMeta(clusterName, &gOpt); err != nil {
 				return err
 			}
-			if err := displayClusterTopology(clusterName, &options); err != nil {
+			if err := displayClusterTopology(clusterName, &gOpt); err != nil {
 				return err
 			}
 
@@ -56,13 +55,12 @@ func newDisplayCmd() *cobra.Command {
 			if err != nil {
 				return errors.AddStack(err)
 			}
-			return destroyTombstoneIfNeed(clusterName, metadata, options)
+			return destroyTombstoneIfNeed(clusterName, metadata, gOpt)
 		},
 	}
 
-	cmd.Flags().StringSliceVarP(&options.Roles, "role", "R", nil, "Only display specified roles")
-	cmd.Flags().StringSliceVarP(&options.Nodes, "node", "N", nil, "Only display specified nodes")
-	cmd.Flags().Int64Var(&options.OptTimeout, "wait-timeout", 60, "Timeout in seconds to wait for an operation to complete, ignored for operations that don't fit.")
+	cmd.Flags().StringSliceVarP(&gOpt.Roles, "role", "R", nil, "Only display specified roles")
+	cmd.Flags().StringSliceVarP(&gOpt.Nodes, "node", "N", nil, "Only display specified nodes")
 
 	return cmd
 }
@@ -99,7 +97,7 @@ func destroyTombstoneIfNeed(clusterName string, metadata *meta.ClusterMeta, opt 
 		return errors.AddStack(err)
 	}
 
-	err = ctx.SetClusterSSH(topo, metadata.User, sshTimeout)
+	err = ctx.SetClusterSSH(topo, metadata.User, gOpt.SSHTimeout)
 	if err != nil {
 		return errors.AddStack(err)
 	}
@@ -145,7 +143,7 @@ func displayClusterTopology(clusterName string, opt *operator.Options) error {
 		return errors.AddStack(err)
 	}
 
-	err = ctx.SetClusterSSH(topo, metadata.User, sshTimeout)
+	err = ctx.SetClusterSSH(topo, metadata.User, gOpt.SSHTimeout)
 	if err != nil {
 		return errors.AddStack(err)
 	}

--- a/cmd/cluster/command/import.go
+++ b/cmd/cluster/command/import.go
@@ -97,7 +97,7 @@ func newImportCmd() *cobra.Command {
 			}
 
 			// parse config and import nodes
-			if err = ansible.ParseAndImportInventory(ansibleDir, clsMeta, inv, sshTimeout); err != nil {
+			if err = ansible.ParseAndImportInventory(ansibleDir, clsMeta, inv, gOpt.SSHTimeout); err != nil {
 				return err
 			}
 
@@ -117,7 +117,7 @@ func newImportCmd() *cobra.Command {
 			}
 
 			// copy config files form deployment servers
-			if err = ansible.ImportConfig(clsName, clsMeta, sshTimeout); err != nil {
+			if err = ansible.ImportConfig(clsName, clsMeta, gOpt.SSHTimeout); err != nil {
 				return err
 			}
 

--- a/cmd/cluster/command/patch.go
+++ b/cmd/cluster/command/patch.go
@@ -35,7 +35,6 @@ import (
 func newPatchCmd() *cobra.Command {
 	var (
 		overwrite bool
-		options   operator.Options
 	)
 	cmd := &cobra.Command{
 		Use:   "patch <cluster-name> <package-path>",
@@ -45,23 +44,21 @@ func newPatchCmd() *cobra.Command {
 				return cmd.Help()
 			}
 
-			if err := validRoles(options.Roles); err != nil {
+			if err := validRoles(gOpt.Roles); err != nil {
 				return err
 			}
 
-			if len(options.Nodes) == 0 && len(options.Roles) == 0 {
+			if len(gOpt.Nodes) == 0 && len(gOpt.Roles) == 0 {
 				return errors.New("the flag -R or -N must be specified at least one")
 			}
-			return patch(args[0], args[1], options, overwrite)
+			return patch(args[0], args[1], gOpt, overwrite)
 		},
 	}
 
 	cmd.Flags().BoolVar(&overwrite, "overwrite", false, "Use this package in the future scale-out operations")
-	cmd.Flags().StringSliceVarP(&options.Nodes, "node", "N", nil, "Specify the nodes")
-	cmd.Flags().StringSliceVarP(&options.Roles, "role", "R", nil, "Specify the role")
-	cmd.Flags().Int64Var(&options.APITimeout, "transfer-timeout", 300, "Timeout in seconds when transferring PD and TiKV store leaders")
-	cmd.Flags().Int64Var(&options.OptTimeout, "wait-timeout", 60, "Timeout in seconds to wait for an operation to complete, ignored for operations that don't fit.")
-
+	cmd.Flags().StringSliceVarP(&gOpt.Nodes, "node", "N", nil, "Specify the nodes")
+	cmd.Flags().StringSliceVarP(&gOpt.Roles, "role", "R", nil, "Specify the role")
+	cmd.Flags().Int64Var(&gOpt.APITimeout, "transfer-timeout", 300, "Timeout in seconds when transferring PD and TiKV store leaders")
 	return cmd
 }
 
@@ -100,7 +97,7 @@ func patch(clusterName, packagePath string, options operator.Options, overwrite 
 		SSHKeySet(
 			meta.ClusterPath(clusterName, "ssh", "id_rsa"),
 			meta.ClusterPath(clusterName, "ssh", "id_rsa.pub")).
-		ClusterSSH(metadata.Topology, metadata.User, sshTimeout).
+		ClusterSSH(metadata.Topology, metadata.User, gOpt.SSHTimeout).
 		Parallel(replacePackageTasks...).
 		ClusterOperate(metadata.Topology, operator.UpgradeOperation, options).
 		Build()

--- a/cmd/cluster/command/patch.go
+++ b/cmd/cluster/command/patch.go
@@ -59,7 +59,8 @@ func newPatchCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&overwrite, "overwrite", false, "Use this package in the future scale-out operations")
 	cmd.Flags().StringSliceVarP(&options.Nodes, "node", "N", nil, "Specify the nodes")
 	cmd.Flags().StringSliceVarP(&options.Roles, "role", "R", nil, "Specify the role")
-	cmd.Flags().Int64Var(&options.Timeout, "transfer-timeout", 300, "Timeout in seconds when transferring PD and TiKV store leaders")
+	cmd.Flags().Int64Var(&options.APITimeout, "transfer-timeout", 300, "Timeout in seconds when transferring PD and TiKV store leaders")
+	cmd.Flags().Int64Var(&options.OptTimeout, "wait-timeout", 60, "Timeout in seconds to wait for an operation to complete, ignored for operations that don't fit.")
 
 	return cmd
 }

--- a/cmd/cluster/command/reload.go
+++ b/cmd/cluster/command/reload.go
@@ -73,7 +73,8 @@ func newReloadCmd() *cobra.Command {
 
 	cmd.Flags().StringSliceVarP(&options.Roles, "role", "R", nil, "Only start specified roles")
 	cmd.Flags().StringSliceVarP(&options.Nodes, "node", "N", nil, "Only start specified nodes")
-	cmd.Flags().Int64Var(&options.Timeout, "transfer-timeout", 300, "Timeout in seconds when transferring PD and TiKV store leaders")
+	cmd.Flags().Int64Var(&options.APITimeout, "transfer-timeout", 300, "Timeout in seconds when transferring PD and TiKV store leaders")
+	cmd.Flags().Int64Var(&options.OptTimeout, "wait-timeout", 60, "Timeout in seconds to wait for an operation to complete, ignored for operations that don't fit.")
 
 	return cmd
 }

--- a/cmd/cluster/command/reload.go
+++ b/cmd/cluster/command/reload.go
@@ -27,8 +27,6 @@ import (
 )
 
 func newReloadCmd() *cobra.Command {
-	var options operator.Options
-
 	cmd := &cobra.Command{
 		Use:   "reload <cluster-name>",
 		Short: "Reload a TiDB cluster's config and restart if needed",
@@ -37,7 +35,7 @@ func newReloadCmd() *cobra.Command {
 				return cmd.Help()
 			}
 
-			if err := validRoles(options.Roles); err != nil {
+			if err := validRoles(gOpt.Roles); err != nil {
 				return err
 			}
 
@@ -52,7 +50,7 @@ func newReloadCmd() *cobra.Command {
 				return err
 			}
 
-			t, err := buildReloadTask(clusterName, metadata, options)
+			t, err := buildReloadTask(clusterName, metadata, gOpt)
 			if err != nil {
 				return err
 			}
@@ -71,10 +69,9 @@ func newReloadCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringSliceVarP(&options.Roles, "role", "R", nil, "Only start specified roles")
-	cmd.Flags().StringSliceVarP(&options.Nodes, "node", "N", nil, "Only start specified nodes")
-	cmd.Flags().Int64Var(&options.APITimeout, "transfer-timeout", 300, "Timeout in seconds when transferring PD and TiKV store leaders")
-	cmd.Flags().Int64Var(&options.OptTimeout, "wait-timeout", 60, "Timeout in seconds to wait for an operation to complete, ignored for operations that don't fit.")
+	cmd.Flags().StringSliceVarP(&gOpt.Roles, "role", "R", nil, "Only start specified roles")
+	cmd.Flags().StringSliceVarP(&gOpt.Nodes, "node", "N", nil, "Only start specified nodes")
+	cmd.Flags().Int64Var(&gOpt.APITimeout, "transfer-timeout", 300, "Timeout in seconds when transferring PD and TiKV store leaders")
 
 	return cmd
 }
@@ -97,7 +94,7 @@ func buildReloadTask(
 		logDir := clusterutil.Abs(metadata.User, inst.LogDir())
 
 		// Download and copy the latest component to remote if the cluster is imported from Ansible
-		tb := task.NewBuilder().UserSSH(inst.GetHost(), inst.GetSSHPort(), metadata.User, sshTimeout)
+		tb := task.NewBuilder().UserSSH(inst.GetHost(), inst.GetSSHPort(), metadata.User, gOpt.SSHTimeout)
 		if inst.IsImported() {
 			switch compName := inst.ComponentName(); compName {
 			case meta.ComponentGrafana, meta.ComponentPrometheus, meta.ComponentAlertManager:
@@ -123,7 +120,7 @@ func buildReloadTask(
 		SSHKeySet(
 			meta.ClusterPath(clusterName, "ssh", "id_rsa"),
 			meta.ClusterPath(clusterName, "ssh", "id_rsa.pub")).
-		ClusterSSH(metadata.Topology, metadata.User, sshTimeout).
+		ClusterSSH(metadata.Topology, metadata.User, gOpt.SSHTimeout).
 		Parallel(refreshConfigTasks...).
 		ClusterOperate(metadata.Topology, operator.UpgradeOperation, options).
 		Build()

--- a/cmd/cluster/command/restart.go
+++ b/cmd/cluster/command/restart.go
@@ -75,5 +75,7 @@ func newRestartCmd() *cobra.Command {
 
 	cmd.Flags().StringSliceVarP(&options.Roles, "role", "R", nil, "Only restart specified roles")
 	cmd.Flags().StringSliceVarP(&options.Nodes, "node", "N", nil, "Only restart specified nodes")
+	cmd.Flags().Int64Var(&options.OptTimeout, "wait-timeout", 60, "Timeout in seconds to wait for an operation to complete, ignored for operations that don't fit.")
+
 	return cmd
 }

--- a/cmd/cluster/command/restart.go
+++ b/cmd/cluster/command/restart.go
@@ -26,8 +26,6 @@ import (
 )
 
 func newRestartCmd() *cobra.Command {
-	var options operator.Options
-
 	cmd := &cobra.Command{
 		Use:   "restart <cluster-name>",
 		Short: "Restart a TiDB cluster",
@@ -36,7 +34,7 @@ func newRestartCmd() *cobra.Command {
 				return cmd.Help()
 			}
 
-			if err := validRoles(options.Roles); err != nil {
+			if err := validRoles(gOpt.Roles); err != nil {
 				return err
 			}
 
@@ -55,8 +53,8 @@ func newRestartCmd() *cobra.Command {
 				SSHKeySet(
 					meta.ClusterPath(clusterName, "ssh", "id_rsa"),
 					meta.ClusterPath(clusterName, "ssh", "id_rsa.pub")).
-				ClusterSSH(metadata.Topology, metadata.User, sshTimeout).
-				ClusterOperate(metadata.Topology, operator.RestartOperation, options).
+				ClusterSSH(metadata.Topology, metadata.User, gOpt.SSHTimeout).
+				ClusterOperate(metadata.Topology, operator.RestartOperation, gOpt).
 				Build()
 
 			if err := t.Execute(task.NewContext()); err != nil {
@@ -73,9 +71,8 @@ func newRestartCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringSliceVarP(&options.Roles, "role", "R", nil, "Only restart specified roles")
-	cmd.Flags().StringSliceVarP(&options.Nodes, "node", "N", nil, "Only restart specified nodes")
-	cmd.Flags().Int64Var(&options.OptTimeout, "wait-timeout", 60, "Timeout in seconds to wait for an operation to complete, ignored for operations that don't fit.")
+	cmd.Flags().StringSliceVarP(&gOpt.Roles, "role", "R", nil, "Only restart specified roles")
+	cmd.Flags().StringSliceVarP(&gOpt.Nodes, "node", "N", nil, "Only restart specified nodes")
 
 	return cmd
 }

--- a/cmd/cluster/command/root.go
+++ b/cmd/cluster/command/root.go
@@ -26,6 +26,7 @@ import (
 	"github.com/pingcap-incubator/tiup-cluster/pkg/flags"
 	"github.com/pingcap-incubator/tiup-cluster/pkg/logger"
 	"github.com/pingcap-incubator/tiup-cluster/pkg/meta"
+	operator "github.com/pingcap-incubator/tiup-cluster/pkg/operation"
 	"github.com/pingcap-incubator/tiup-cluster/pkg/version"
 	"github.com/pingcap-incubator/tiup/pkg/localdata"
 	tiupmeta "github.com/pingcap-incubator/tiup/pkg/meta"
@@ -34,11 +35,10 @@ import (
 	"go.uber.org/zap"
 )
 
-var rootCmd *cobra.Command
-
 var (
 	errNS       = errorx.NewNamespace("cmd")
-	sshTimeout  int64 // timeout in seconds when connecting an SSH server
+	rootCmd     *cobra.Command
+	gOpt        operator.Options
 	skipConfirm bool
 )
 
@@ -76,7 +76,8 @@ func init() {
 
 	cliutil.BeautifyCobraUsageAndHelp(rootCmd)
 
-	rootCmd.PersistentFlags().Int64Var(&sshTimeout, "ssh-timeout", 5, "Timeout in seconds to connect host via SSH, ignored for operations that don't need an SSH connection.")
+	rootCmd.PersistentFlags().Int64Var(&gOpt.SSHTimeout, "ssh-timeout", 5, "Timeout in seconds to connect host via SSH, ignored for operations that don't need an SSH connection.")
+	rootCmd.PersistentFlags().Int64Var(&gOpt.OptTimeout, "wait-timeout", 60, "Timeout in seconds to wait for an operation to complete, ignored for operations that don't fit.")
 	rootCmd.PersistentFlags().BoolVarP(&skipConfirm, "yes", "y", false, "Skip all confirmations and assumes 'yes'")
 
 	rootCmd.AddCommand(

--- a/cmd/cluster/command/scale_in.go
+++ b/cmd/cluster/command/scale_in.go
@@ -60,7 +60,8 @@ func newScaleInCmd() *cobra.Command {
 	}
 
 	cmd.Flags().StringSliceVarP(&options.Nodes, "node", "N", nil, "Specify the nodes")
-	cmd.Flags().Int64Var(&options.Timeout, "transfer-timeout", 300, "Timeout in seconds when transferring PD and TiKV store leaders")
+	cmd.Flags().Int64Var(&options.APITimeout, "transfer-timeout", 300, "Timeout in seconds when transferring PD and TiKV store leaders")
+	cmd.Flags().Int64Var(&options.OptTimeout, "wait-timeout", 60, "Timeout in seconds to wait for an operation to complete, ignored for operations that don't fit.")
 	cmd.Flags().BoolVar(&options.Force, "force", false, "Force just try stop and destroy instance before removing the instance from topo")
 
 	_ = cmd.MarkFlagRequired("node")

--- a/cmd/cluster/command/scale_in.go
+++ b/cmd/cluster/command/scale_in.go
@@ -32,9 +32,6 @@ import (
 )
 
 func newScaleInCmd() *cobra.Command {
-	var (
-		options operator.Options
-	)
 	cmd := &cobra.Command{
 		Use:   "scale-in <cluster-name>",
 		Short: "Scale in a TiDB cluster",
@@ -47,7 +44,7 @@ func newScaleInCmd() *cobra.Command {
 			if !skipConfirm {
 				if err := cliutil.PromptForConfirmOrAbortError(
 					"This operation will delete the %s nodes in `%s` and all their data.\nDo you want to continue? [y/N]:",
-					strings.Join(options.Nodes, ","),
+					strings.Join(gOpt.Nodes, ","),
 					color.HiYellowString(clusterName)); err != nil {
 					return err
 				}
@@ -55,14 +52,13 @@ func newScaleInCmd() *cobra.Command {
 			}
 
 			logger.EnableAuditLog()
-			return scaleIn(clusterName, options)
+			return scaleIn(clusterName, gOpt)
 		},
 	}
 
-	cmd.Flags().StringSliceVarP(&options.Nodes, "node", "N", nil, "Specify the nodes")
-	cmd.Flags().Int64Var(&options.APITimeout, "transfer-timeout", 300, "Timeout in seconds when transferring PD and TiKV store leaders")
-	cmd.Flags().Int64Var(&options.OptTimeout, "wait-timeout", 60, "Timeout in seconds to wait for an operation to complete, ignored for operations that don't fit.")
-	cmd.Flags().BoolVar(&options.Force, "force", false, "Force just try stop and destroy instance before removing the instance from topo")
+	cmd.Flags().StringSliceVarP(&gOpt.Nodes, "node", "N", nil, "Specify the nodes")
+	cmd.Flags().Int64Var(&gOpt.APITimeout, "transfer-timeout", 300, "Timeout in seconds when transferring PD and TiKV store leaders")
+	cmd.Flags().BoolVar(&gOpt.Force, "force", false, "Force just try stop and destroy instance before removing the instance from topo")
 
 	_ = cmd.MarkFlagRequired("node")
 
@@ -122,7 +118,7 @@ func scaleIn(clusterName string, options operator.Options) error {
 		SSHKeySet(
 			meta.ClusterPath(clusterName, "ssh", "id_rsa"),
 			meta.ClusterPath(clusterName, "ssh", "id_rsa.pub")).
-		ClusterSSH(metadata.Topology, metadata.User, sshTimeout)
+		ClusterSSH(metadata.Topology, metadata.User, gOpt.SSHTimeout)
 
 	if !options.Force {
 		b.ClusterOperate(metadata.Topology, operator.ScaleInOperation, options).

--- a/cmd/cluster/command/start.go
+++ b/cmd/cluster/command/start.go
@@ -51,6 +51,8 @@ func newStartCmd() *cobra.Command {
 
 	cmd.Flags().StringSliceVarP(&options.Roles, "role", "R", nil, "Only start specified roles")
 	cmd.Flags().StringSliceVarP(&options.Nodes, "node", "N", nil, "Only start specified nodes")
+	cmd.Flags().Int64Var(&options.OptTimeout, "wait-timeout", 60, "Timeout in seconds to wait for an operation to complete, ignored for operations that don't fit.")
+
 	return cmd
 }
 

--- a/cmd/cluster/command/start.go
+++ b/cmd/cluster/command/start.go
@@ -26,8 +26,6 @@ import (
 )
 
 func newStartCmd() *cobra.Command {
-	var options operator.Options
-
 	cmd := &cobra.Command{
 		Use:   "start <cluster-name>",
 		Short: "Start a TiDB cluster",
@@ -36,7 +34,7 @@ func newStartCmd() *cobra.Command {
 				return cmd.Help()
 			}
 
-			if err := validRoles(options.Roles); err != nil {
+			if err := validRoles(gOpt.Roles); err != nil {
 				return nil
 			}
 
@@ -45,13 +43,12 @@ func newStartCmd() *cobra.Command {
 				return errors.Errorf("cannot start non-exists cluster %s", clusterName)
 			}
 
-			return startCluster(clusterName, options)
+			return startCluster(clusterName, gOpt)
 		},
 	}
 
-	cmd.Flags().StringSliceVarP(&options.Roles, "role", "R", nil, "Only start specified roles")
-	cmd.Flags().StringSliceVarP(&options.Nodes, "node", "N", nil, "Only start specified nodes")
-	cmd.Flags().Int64Var(&options.OptTimeout, "wait-timeout", 60, "Timeout in seconds to wait for an operation to complete, ignored for operations that don't fit.")
+	cmd.Flags().StringSliceVarP(&gOpt.Roles, "role", "R", nil, "Only start specified roles")
+	cmd.Flags().StringSliceVarP(&gOpt.Nodes, "node", "N", nil, "Only start specified nodes")
 
 	return cmd
 }
@@ -68,7 +65,7 @@ func startCluster(clusterName string, options operator.Options) error {
 		SSHKeySet(
 			meta.ClusterPath(clusterName, "ssh", "id_rsa"),
 			meta.ClusterPath(clusterName, "ssh", "id_rsa.pub")).
-		ClusterSSH(metadata.Topology, metadata.User, sshTimeout).
+		ClusterSSH(metadata.Topology, metadata.User, gOpt.SSHTimeout).
 		ClusterOperate(metadata.Topology, operator.StartOperation, options).
 		Build()
 

--- a/cmd/cluster/command/stop.go
+++ b/cmd/cluster/command/stop.go
@@ -26,8 +26,6 @@ import (
 )
 
 func newStopCmd() *cobra.Command {
-	var options operator.Options
-
 	cmd := &cobra.Command{
 		Use:   "stop <cluster-name>",
 		Short: "Stop a TiDB cluster",
@@ -36,7 +34,7 @@ func newStopCmd() *cobra.Command {
 				return cmd.Help()
 			}
 
-			if err := validRoles(options.Roles); err != nil {
+			if err := validRoles(gOpt.Roles); err != nil {
 				return err
 			}
 
@@ -55,8 +53,8 @@ func newStopCmd() *cobra.Command {
 				SSHKeySet(
 					meta.ClusterPath(clusterName, "ssh", "id_rsa"),
 					meta.ClusterPath(clusterName, "ssh", "id_rsa.pub")).
-				ClusterSSH(metadata.Topology, metadata.User, sshTimeout).
-				ClusterOperate(metadata.Topology, operator.StopOperation, options).
+				ClusterSSH(metadata.Topology, metadata.User, gOpt.SSHTimeout).
+				ClusterOperate(metadata.Topology, operator.StopOperation, gOpt).
 				Build()
 
 			if err := t.Execute(task.NewContext()); err != nil {
@@ -73,9 +71,8 @@ func newStopCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringSliceVarP(&options.Roles, "role", "R", nil, "Only stop specified roles")
-	cmd.Flags().StringSliceVarP(&options.Nodes, "node", "N", nil, "Only stop specified nodes")
-	cmd.Flags().Int64Var(&options.OptTimeout, "wait-timeout", 60, "Timeout in seconds to wait for an operation to complete, ignored for operations that don't fit.")
+	cmd.Flags().StringSliceVarP(&gOpt.Roles, "role", "R", nil, "Only stop specified roles")
+	cmd.Flags().StringSliceVarP(&gOpt.Nodes, "node", "N", nil, "Only stop specified nodes")
 
 	return cmd
 }

--- a/cmd/cluster/command/stop.go
+++ b/cmd/cluster/command/stop.go
@@ -75,5 +75,7 @@ func newStopCmd() *cobra.Command {
 
 	cmd.Flags().StringSliceVarP(&options.Roles, "role", "R", nil, "Only stop specified roles")
 	cmd.Flags().StringSliceVarP(&options.Nodes, "node", "N", nil, "Only stop specified nodes")
+	cmd.Flags().Int64Var(&options.OptTimeout, "wait-timeout", 60, "Timeout in seconds to wait for an operation to complete, ignored for operations that don't fit.")
+
 	return cmd
 }

--- a/cmd/cluster/command/upgrade.go
+++ b/cmd/cluster/command/upgrade.go
@@ -49,7 +49,8 @@ func newUpgradeCmd() *cobra.Command {
 		},
 	}
 	cmd.Flags().BoolVar(&opt.options.Force, "force", false, "Force upgrade won't transfer leader")
-	cmd.Flags().Int64Var(&opt.options.Timeout, "transfer-timeout", 300, "Timeout in seconds when transferring PD and TiKV store leaders")
+	cmd.Flags().Int64Var(&opt.options.APITimeout, "transfer-timeout", 300, "Timeout in seconds when transferring PD and TiKV store leaders")
+	cmd.Flags().Int64Var(&opt.options.OptTimeout, "wait-timeout", 60, "Timeout in seconds to wait for an operation to complete, ignored for operations that don't fit.")
 
 	return cmd
 }

--- a/cmd/cluster/command/upgrade.go
+++ b/cmd/cluster/command/upgrade.go
@@ -45,7 +45,6 @@ func newUpgradeCmd() *cobra.Command {
 	}
 	cmd.Flags().BoolVar(&gOpt.Force, "force", false, "Force upgrade won't transfer leader")
 	cmd.Flags().Int64Var(&gOpt.APITimeout, "transfer-timeout", 300, "Timeout in seconds when transferring PD and TiKV store leaders")
-	cmd.Flags().Int64Var(&gOpt.OptTimeout, "wait-timeout", 60, "Timeout in seconds to wait for an operation to complete, ignored for operations that don't fit.")
 
 	return cmd
 }

--- a/cmd/dm/command/deploy.go
+++ b/cmd/dm/command/deploy.go
@@ -186,7 +186,7 @@ func deploy(clusterName, clusterVersion, topoFile string, opt deployOptions) err
 					sshConnProps.Password,
 					sshConnProps.IdentityFile,
 					sshConnProps.IdentityFilePassphrase,
-					sshTimeout,
+					gOpt.SSHTimeout,
 				).
 				EnvInit(inst.GetHost(), globalOptions.User).
 				Mkdir(globalOptions.User, inst.GetHost(), dirs...).
@@ -208,7 +208,7 @@ func deploy(clusterName, clusterVersion, topoFile string, opt deployOptions) err
 		logDir := clusterutil.Abs(globalOptions.User, inst.LogDir())
 		// Deploy component
 		t := task.NewBuilder().
-			UserSSH(inst.GetHost(), inst.GetSSHPort(), globalOptions.User, sshTimeout).
+			UserSSH(inst.GetHost(), inst.GetSSHPort(), globalOptions.User, gOpt.SSHTimeout).
 			Mkdir(globalOptions.User, inst.GetHost(),
 				deployDir, dataDir, logDir,
 				filepath.Join(deployDir, "bin"),

--- a/cmd/dm/command/destroy.go
+++ b/cmd/dm/command/destroy.go
@@ -63,7 +63,7 @@ func newDestroyCmd() *cobra.Command {
 				SSHKeySet(
 					meta.ClusterPath(clusterName, "ssh", "id_rsa"),
 					meta.ClusterPath(clusterName, "ssh", "id_rsa.pub")).
-				ClusterSSH(metadata.Topology, metadata.User, sshTimeout).
+				ClusterSSH(metadata.Topology, metadata.User, gOpt.SSHTimeout).
 				ClusterOperate(metadata.Topology, operator.StopOperation, operator.Options{}).
 				ClusterOperate(metadata.Topology, operator.DestroyOperation, operator.Options{}).
 				Build()

--- a/cmd/dm/command/root.go
+++ b/cmd/dm/command/root.go
@@ -26,6 +26,7 @@ import (
 	"github.com/pingcap-incubator/tiup-cluster/pkg/flags"
 	"github.com/pingcap-incubator/tiup-cluster/pkg/logger"
 	"github.com/pingcap-incubator/tiup-cluster/pkg/meta"
+	operator "github.com/pingcap-incubator/tiup-cluster/pkg/operation"
 	"github.com/pingcap-incubator/tiup-cluster/pkg/version"
 	"github.com/pingcap-incubator/tiup/pkg/localdata"
 	tiupmeta "github.com/pingcap-incubator/tiup/pkg/meta"
@@ -38,7 +39,7 @@ var rootCmd *cobra.Command
 
 var (
 	errNS       = errorx.NewNamespace("cmd")
-	sshTimeout  int64 // timeout in seconds when connecting an SSH server
+	gOpt        operator.Options
 	skipConfirm bool
 )
 
@@ -76,7 +77,8 @@ func init() {
 
 	cliutil.BeautifyCobraUsageAndHelp(rootCmd)
 
-	rootCmd.PersistentFlags().Int64Var(&sshTimeout, "ssh-timeout", 5, "Timeout in seconds to connect host via SSH, ignored for operations that don't need an SSH connection.")
+	rootCmd.PersistentFlags().Int64Var(&gOpt.SSHTimeout, "ssh-timeout", 5, "Timeout in seconds to connect host via SSH, ignored for operations that don't need an SSH connection.")
+	rootCmd.PersistentFlags().Int64Var(&gOpt.OptTimeout, "wait-timeout", 60, "Timeout in seconds to wait for an operation to complete, ignored for operations that don't fit.")
 	rootCmd.PersistentFlags().BoolVarP(&skipConfirm, "yes", "y", false, "Skip all confirmations and assumes 'yes'")
 
 	rootCmd.AddCommand(

--- a/cmd/dm/command/start.go
+++ b/cmd/dm/command/start.go
@@ -47,6 +47,8 @@ func newStartCmd() *cobra.Command {
 
 	cmd.Flags().StringSliceVarP(&options.Roles, "role", "R", nil, "Only start specified roles")
 	cmd.Flags().StringSliceVarP(&options.Nodes, "node", "N", nil, "Only start specified nodes")
+	cmd.Flags().Int64Var(&options.OptTimeout, "wait-timeout", 60, "Timeout in seconds to wait for an operation to complete, ignored for operations that don't fit.")
+
 	return cmd
 }
 

--- a/cmd/dm/command/start.go
+++ b/cmd/dm/command/start.go
@@ -26,8 +26,6 @@ import (
 )
 
 func newStartCmd() *cobra.Command {
-	var options operator.Options
-
 	cmd := &cobra.Command{
 		Use:   "start <cluster-name>",
 		Short: "Start a DM cluster",
@@ -41,13 +39,12 @@ func newStartCmd() *cobra.Command {
 				return errors.Errorf("cannot start non-exists cluster %s", clusterName)
 			}
 
-			return startCluster(clusterName, options)
+			return startCluster(clusterName, gOpt)
 		},
 	}
 
-	cmd.Flags().StringSliceVarP(&options.Roles, "role", "R", nil, "Only start specified roles")
-	cmd.Flags().StringSliceVarP(&options.Nodes, "node", "N", nil, "Only start specified nodes")
-	cmd.Flags().Int64Var(&options.OptTimeout, "wait-timeout", 60, "Timeout in seconds to wait for an operation to complete, ignored for operations that don't fit.")
+	cmd.Flags().StringSliceVarP(&gOpt.Roles, "role", "R", nil, "Only start specified roles")
+	cmd.Flags().StringSliceVarP(&gOpt.Nodes, "node", "N", nil, "Only start specified nodes")
 
 	return cmd
 }
@@ -64,7 +61,7 @@ func startCluster(clusterName string, options operator.Options) error {
 		SSHKeySet(
 			meta.ClusterPath(clusterName, "ssh", "id_rsa"),
 			meta.ClusterPath(clusterName, "ssh", "id_rsa.pub")).
-		ClusterSSH(metadata.Topology, metadata.User, sshTimeout).
+		ClusterSSH(metadata.Topology, metadata.User, gOpt.SSHTimeout).
 		ClusterOperate(metadata.Topology, operator.StartOperation, options).
 		Build()
 

--- a/cmd/dm/command/stop.go
+++ b/cmd/dm/command/stop.go
@@ -26,8 +26,6 @@ import (
 )
 
 func newStopCmd() *cobra.Command {
-	var options operator.Options
-
 	cmd := &cobra.Command{
 		Use:   "stop <cluster-name>",
 		Short: "Stop a DM cluster",
@@ -51,8 +49,8 @@ func newStopCmd() *cobra.Command {
 				SSHKeySet(
 					meta.ClusterPath(clusterName, "ssh", "id_rsa"),
 					meta.ClusterPath(clusterName, "ssh", "id_rsa.pub")).
-				ClusterSSH(metadata.Topology, metadata.User, sshTimeout).
-				ClusterOperate(metadata.Topology, operator.StopOperation, options).
+				ClusterSSH(metadata.Topology, metadata.User, gOpt.SSHTimeout).
+				ClusterOperate(metadata.Topology, operator.StopOperation, gOpt).
 				Build()
 
 			if err := t.Execute(task.NewContext()); err != nil {
@@ -69,9 +67,8 @@ func newStopCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringSliceVarP(&options.Roles, "role", "R", nil, "Only stop specified roles")
-	cmd.Flags().StringSliceVarP(&options.Nodes, "node", "N", nil, "Only stop specified nodes")
-	cmd.Flags().Int64Var(&options.OptTimeout, "wait-timeout", 60, "Timeout in seconds to wait for an operation to complete, ignored for operations that don't fit.")
+	cmd.Flags().StringSliceVarP(&gOpt.Roles, "role", "R", nil, "Only stop specified roles")
+	cmd.Flags().StringSliceVarP(&gOpt.Nodes, "node", "N", nil, "Only stop specified nodes")
 
 	return cmd
 }

--- a/cmd/dm/command/stop.go
+++ b/cmd/dm/command/stop.go
@@ -71,5 +71,7 @@ func newStopCmd() *cobra.Command {
 
 	cmd.Flags().StringSliceVarP(&options.Roles, "role", "R", nil, "Only stop specified roles")
 	cmd.Flags().StringSliceVarP(&options.Nodes, "node", "N", nil, "Only stop specified nodes")
+	cmd.Flags().Int64Var(&options.OptTimeout, "wait-timeout", 60, "Timeout in seconds to wait for an operation to complete, ignored for operations that don't fit.")
+
 	return cmd
 }

--- a/pkg/meta/logic_dm.go
+++ b/pkg/meta/logic_dm.go
@@ -44,13 +44,13 @@ type dmInstance struct {
 }
 
 // Ready implements Instance interface
-func (i *dmInstance) Ready(e executor.TiOpsExecutor) error {
-	return PortStarted(e, i.port)
+func (i *dmInstance) Ready(e executor.TiOpsExecutor, timeout int64) error {
+	return PortStarted(e, i.port, timeout)
 }
 
 // WaitForDown implements Instance interface
-func (i *dmInstance) WaitForDown(e executor.TiOpsExecutor) error {
-	return PortStopped(e, i.port)
+func (i *dmInstance) WaitForDown(e executor.TiOpsExecutor, timeout int64) error {
+	return PortStopped(e, i.port, timeout)
 }
 
 func (i *dmInstance) InitConfig(e executor.TiOpsExecutor, _, _, user string, paths DirPaths) error {

--- a/pkg/module/wait_for.go
+++ b/pkg/module/wait_for.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/pingcap-incubator/tiup-cluster/pkg/executor"
+	"github.com/pingcap-incubator/tiup-cluster/pkg/log"
 	"github.com/pingcap-incubator/tiup-cluster/pkg/utils"
 	"github.com/pingcap/errors"
 )
@@ -85,7 +86,7 @@ func (w *WaitFor) Execute(e executor.TiOpsExecutor) (err error) {
 		}
 		return err
 	}, retryOpt); err != nil {
-		// TODO: add a debug log about the real err returned by utils.Retry()
+		log.Debugf("retry error: %s", err)
 		return errors.Errorf("timed out waiting for port %d to be %s after %s", w.c.Port, w.c.State, w.c.Timeout)
 	}
 	return nil

--- a/pkg/operation/operation.go
+++ b/pkg/operation/operation.go
@@ -23,10 +23,11 @@ import (
 
 // Options represents the operation options
 type Options struct {
-	Roles   []string
-	Nodes   []string
-	Force   bool  // Option for upgrade subcommand
-	Timeout int64 // timeout in seconds for operations that support it, not to confuse with SSH timeout
+	Roles      []string
+	Nodes      []string
+	Force      bool  // Option for upgrade subcommand
+	OptTimeout int64 // timeout in seconds for operations that support it, not to confuse with SSH timeout
+	APITimeout int64 // timeout in seconds for API operations that support it, like transfering store leader
 }
 
 // Operation represents the type of cluster operation

--- a/pkg/operation/operation.go
+++ b/pkg/operation/operation.go
@@ -26,6 +26,7 @@ type Options struct {
 	Roles      []string
 	Nodes      []string
 	Force      bool  // Option for upgrade subcommand
+	SSHTimeout int64 // timeout in seconds when connecting an SSH server
 	OptTimeout int64 // timeout in seconds for operations that support it, not to confuse with SSH timeout
 	APITimeout int64 // timeout in seconds for API operations that support it, like transfering store leader
 }

--- a/pkg/operation/scale_in.go
+++ b/pkg/operation/scale_in.go
@@ -122,7 +122,7 @@ func ScaleInCluster(
 				if err := StopComponent(getter, []meta.Instance{instance}); err != nil {
 					log.Warnf("failed to stop %s: %v", component.Name(), err)
 				}
-				if err := DestroyComponent(getter, []meta.Instance{instance}); err != nil {
+				if err := DestroyComponent(getter, []meta.Instance{instance}, options.OptTimeout); err != nil {
 					log.Warnf("failed to destroy %s: %v", component.Name(), err)
 				}
 
@@ -155,7 +155,7 @@ func ScaleInCluster(
 	}
 
 	timeoutOpt := &utils.RetryOption{
-		Timeout: time.Second * time.Duration(options.Timeout),
+		Timeout: time.Second * time.Duration(options.APITimeout),
 		Delay:   time.Second * 5,
 	}
 
@@ -193,7 +193,7 @@ func ScaleInCluster(
 				if err := StopComponent(getter, []meta.Instance{instance}); err != nil {
 					return errors.Annotatef(err, "failed to stop %s", component.Name())
 				}
-				if err := DestroyComponent(getter, []meta.Instance{instance}); err != nil {
+				if err := DestroyComponent(getter, []meta.Instance{instance}, options.OptTimeout); err != nil {
 					return errors.Annotatef(err, "failed to destroy %s", component.Name())
 				}
 			} else {

--- a/pkg/operation/upgrade.go
+++ b/pkg/operation/upgrade.go
@@ -39,7 +39,7 @@ func Upgrade(
 	leaderAware := set.NewStringSet(meta.ComponentPD, meta.ComponentTiKV)
 
 	timeoutOpt := &utils.RetryOption{
-		Timeout: time.Second * time.Duration(options.Timeout),
+		Timeout: time.Second * time.Duration(options.APITimeout),
 		Delay:   time.Second * 2,
 	}
 
@@ -72,7 +72,7 @@ func Upgrade(
 						if err := stopInstance(getter, instance); err != nil {
 							return errors.Annotatef(err, "failed to stop %s", instance.GetHost())
 						}
-						if err := startInstance(getter, instance); err != nil {
+						if err := startInstance(getter, instance, options.OptTimeout); err != nil {
 							return errors.Annotatef(err, "failed to start %s", instance.GetHost())
 						}
 					}
@@ -100,7 +100,7 @@ func Upgrade(
 						if err := stopInstance(getter, instance); err != nil {
 							return errors.Annotatef(err, "failed to stop %s", instance.GetHost())
 						}
-						if err := startInstance(getter, instance); err != nil {
+						if err := startInstance(getter, instance, options.OptTimeout); err != nil {
 							return errors.Annotatef(err, "failed to start %s", instance.GetHost())
 						}
 						// remove store leader evict scheduler after restart
@@ -113,7 +113,7 @@ func Upgrade(
 			}
 		}
 
-		if err := RestartComponent(getter, instances); err != nil {
+		if err := RestartComponent(getter, instances, options.OptTimeout); err != nil {
 			return errors.Annotatef(err, "failed to restart %s", component.Name())
 		}
 	}

--- a/pkg/task/action.go
+++ b/pkg/task/action.go
@@ -56,12 +56,12 @@ func (c *ClusterOperate) Execute(ctx *Context) error {
 		}
 		operator.PrintClusterStatus(ctx, c.spec)
 	case operator.DestroyOperation:
-		err := operator.Destroy(ctx, c.spec)
+		err := operator.Destroy(ctx, c.spec, c.options)
 		if err != nil {
 			return errors.Annotate(err, "failed to destroy")
 		}
 	case operator.DestroyTombstoneOperation:
-		_, err := operator.DestroyTombstone(ctx, c.spec, false)
+		_, err := operator.DestroyTombstone(ctx, c.spec, false, c.options)
 		if err != nil {
 			return errors.Annotate(err, "failed to destroy")
 		}


### PR DESCRIPTION
We have logic to "wait for" a port to be up or down during various processes, this operation times out after 1min by default.

For some environment, instance may need longer time to start before they can start serve requests, so add an argument `--wait-timeout` to make it possible for user to set this timeout to a proper value.