### PR TITLE
meta: store imported configs in a dedicated path

### DIFF
--- a/cmd/cluster/command/deploy.go
+++ b/cmd/cluster/command/deploy.go
@@ -283,7 +283,7 @@ func deploy(clusterName, clusterVersion, topoFile string, opt deployOptions) err
 					Deploy: deployDir,
 					Data:   dataDirs,
 					Log:    logDir,
-					Cache:  meta.ClusterPath(clusterName, "config"),
+					Cache:  meta.ClusterPath(clusterName, meta.TempConfigPath),
 				},
 			).
 			BuildAsStep(fmt.Sprintf("  - Copy %s -> %s", inst.ComponentName(), inst.GetHost()))
@@ -405,7 +405,7 @@ func buildMonitoredDeployTask(
 						Deploy: deployDir,
 						Data:   []string{dataDir},
 						Log:    logDir,
-						Cache:  meta.ClusterPath(clusterName, "config"),
+						Cache:  meta.ClusterPath(clusterName, meta.TempConfigPath),
 					},
 				).
 				BuildAsStep(fmt.Sprintf("  - Copy %s -> %s", comp, host))

--- a/cmd/cluster/command/edit_config.go
+++ b/cmd/cluster/command/edit_config.go
@@ -59,7 +59,7 @@ func newEditConfigCmd() *cobra.Command {
 }
 
 // 1. Write Topology to a temporary file.
-// 2. Open file in editro.
+// 2. Open file in editor.
 // 3. Check and update Topology.
 // 4. Save meta file.
 func editTopo(clusterName string, metadata *meta.ClusterMeta) error {

--- a/cmd/cluster/command/reload.go
+++ b/cmd/cluster/command/reload.go
@@ -112,7 +112,7 @@ func buildReloadTask(
 				Deploy: deployDir,
 				Data:   dataDirs,
 				Log:    logDir,
-				Cache:  meta.ClusterPath(clusterName, "config"),
+				Cache:  meta.ClusterPath(clusterName, meta.TempConfigPath),
 			}).Build()
 		refreshConfigTasks = append(refreshConfigTasks, t)
 	})

--- a/cmd/cluster/command/root.go
+++ b/cmd/cluster/command/root.go
@@ -98,7 +98,6 @@ func init() {
 			return cmd.Help()
 		},
 		PersistentPostRunE: func(cmd *cobra.Command, args []string) error {
-
 			return meta.TiupEnv().Repository().Mirror().Close()
 		},
 	}

--- a/cmd/cluster/command/scale_in.go
+++ b/cmd/cluster/command/scale_in.go
@@ -108,7 +108,7 @@ func scaleIn(clusterName string, options operator.Options) error {
 					Deploy: deployDir,
 					Data:   dataDirs,
 					Log:    logDir,
-					Cache:  meta.ClusterPath(clusterName, "config"),
+					Cache:  meta.ClusterPath(clusterName, meta.TempConfigPath),
 				},
 			).Build()
 			regenConfigTasks = append(regenConfigTasks, t)

--- a/cmd/cluster/command/scale_out.go
+++ b/cmd/cluster/command/scale_out.go
@@ -295,7 +295,7 @@ func buildScaleOutTask(
 				Deploy: deployDir,
 				Data:   dataDirs,
 				Log:    logDir,
-				Cache:  meta.ClusterPath(clusterName, "config"),
+				Cache:  meta.ClusterPath(clusterName, meta.TempConfigPath),
 			},
 		).Build()
 		refreshConfigTasks = append(refreshConfigTasks, t)

--- a/cmd/cluster/command/scale_out.go
+++ b/cmd/cluster/command/scale_out.go
@@ -268,6 +268,8 @@ func buildScaleOutTask(
 		deployCompTasks = append(deployCompTasks, t)
 	})
 
+	hasImported := false
+
 	mergedTopo.IterInstance(func(inst meta.Instance) {
 		deployDir := clusterutil.Abs(metadata.User, inst.DeployDir())
 		// data dir would be empty for components which don't need it
@@ -284,6 +286,7 @@ func buildScaleOutTask(
 				tb.Download(compName, inst.OS(), inst.Arch(), version).
 					CopyComponent(compName, inst.OS(), inst.Arch(), version, inst.GetHost(), deployDir)
 			}
+			hasImported = true
 		}
 
 		// Refresh all configuration
@@ -300,6 +303,13 @@ func buildScaleOutTask(
 		).Build()
 		refreshConfigTasks = append(refreshConfigTasks, t)
 	})
+
+	// handle dir scheme changes
+	if hasImported {
+		if err := meta.HandleImportPathMigration(clusterName); err != nil {
+			return task.NewBuilder().Build(), err
+		}
+	}
 
 	nodeInfoTask := task.NewBuilder().Func("Check status", func(ctx *task.Context) error {
 		var err error

--- a/cmd/cluster/command/upgrade.go
+++ b/cmd/cluster/command/upgrade.go
@@ -133,7 +133,7 @@ func upgrade(clusterName, clusterVersion string, opt operator.Options) error {
 						Deploy: deployDir,
 						Data:   dataDirs,
 						Log:    logDir,
-						Cache:  meta.ClusterPath(clusterName, "config"),
+						Cache:  meta.ClusterPath(clusterName, meta.TempConfigPath),
 					},
 				)
 			} else {

--- a/cmd/dm/command/deploy.go
+++ b/cmd/dm/command/deploy.go
@@ -224,7 +224,7 @@ func deploy(clusterName, clusterVersion, topoFile string, opt deployOptions) err
 					Deploy: deployDir,
 					Data:   []string{dataDir},
 					Log:    logDir,
-					Cache:  meta.ClusterPath(clusterName, "config"),
+					Cache:  meta.ClusterPath(clusterName, meta.TempConfigPath),
 				},
 			).
 			BuildAsStep(fmt.Sprintf("  - Copy %s -> %s", inst.ComponentName(), inst.GetHost()))

--- a/pkg/ansible/config.go
+++ b/pkg/ansible/config.go
@@ -45,7 +45,7 @@ func ImportConfig(name string, clsMeta *meta.ClusterMeta, sshTimeout int64) erro
 					UserSSH(inst.GetHost(), inst.GetSSHPort(), clsMeta.User, sshTimeout).
 					CopyFile(filepath.Join(inst.DeployDir(), "conf", inst.ComponentName()+".toml"),
 						meta.ClusterPath(name,
-							"config",
+							meta.AnsibleImportedConfigPath,
 							fmt.Sprintf("%s-%s-%d.toml",
 								inst.ComponentName(),
 								inst.GetHost(),
@@ -62,7 +62,7 @@ func ImportConfig(name string, clsMeta *meta.ClusterMeta, sshTimeout int64) erro
 					UserSSH(inst.GetHost(), inst.GetSSHPort(), clsMeta.User, sshTimeout).
 					CopyFile(filepath.Join(inst.DeployDir(), "conf", inst.ComponentName()+".toml"),
 						meta.ClusterPath(name,
-							"config",
+							meta.AnsibleImportedConfigPath,
 							fmt.Sprintf("%s-%s-%d.toml",
 								inst.ComponentName(),
 								inst.GetHost(),
@@ -71,7 +71,7 @@ func ImportConfig(name string, clsMeta *meta.ClusterMeta, sshTimeout int64) erro
 						true).
 					CopyFile(filepath.Join(inst.DeployDir(), "conf", inst.ComponentName()+"-learner.toml"),
 						meta.ClusterPath(name,
-							"config",
+							meta.AnsibleImportedConfigPath,
 							fmt.Sprintf("%s-learner-%s-%d.toml",
 								inst.ComponentName(),
 								inst.GetHost(),

--- a/pkg/meta/drainer.go
+++ b/pkg/meta/drainer.go
@@ -112,7 +112,7 @@ func (i *DrainerInstance) InitConfig(e executor.TiOpsExecutor, clusterName, clus
 	if i.IsImported() {
 		configPath := ClusterPath(
 			clusterName,
-			"config",
+			AnsibleImportedConfigPath,
 			fmt.Sprintf(
 				"%s-%s-%d.toml",
 				i.ComponentName(),

--- a/pkg/meta/drainer.go
+++ b/pkg/meta/drainer.go
@@ -16,12 +16,10 @@ package meta
 import (
 	"fmt"
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"strconv"
 
 	"github.com/pingcap-incubator/tiup-cluster/pkg/executor"
-	"github.com/pingcap-incubator/tiup-cluster/pkg/log"
 	"github.com/pingcap-incubator/tiup-cluster/pkg/template/scripts"
 )
 
@@ -124,11 +122,6 @@ func (i *DrainerInstance) InitConfig(e executor.TiOpsExecutor, clusterName, clus
 		)
 		importConfig, err := ioutil.ReadFile(configPath)
 		if err != nil {
-			if os.IsNotExist(err) {
-				dirPath := ClusterPath(clusterName)
-				log.Errorf("%s, you may try to rename '%s/config' to '%s/%s'",
-					err, dirPath, dirPath, AnsibleImportedConfigPath)
-			}
 			return err
 		}
 		mergedConfig, err := mergeImported(importConfig, spec.Config)

--- a/pkg/meta/drainer.go
+++ b/pkg/meta/drainer.go
@@ -16,10 +16,12 @@ package meta
 import (
 	"fmt"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strconv"
 
 	"github.com/pingcap-incubator/tiup-cluster/pkg/executor"
+	"github.com/pingcap-incubator/tiup-cluster/pkg/log"
 	"github.com/pingcap-incubator/tiup-cluster/pkg/template/scripts"
 )
 
@@ -122,6 +124,11 @@ func (i *DrainerInstance) InitConfig(e executor.TiOpsExecutor, clusterName, clus
 		)
 		importConfig, err := ioutil.ReadFile(configPath)
 		if err != nil {
+			if os.IsNotExist(err) {
+				dirPath := ClusterPath(clusterName)
+				log.Errorf("%s, you may try to rename '%s/config' to '%s/%s'",
+					err, dirPath, dirPath, AnsibleImportedConfigPath)
+			}
 			return err
 		}
 		mergedConfig, err := mergeImported(importConfig, spec.Config)

--- a/pkg/meta/logic.go
+++ b/pkg/meta/logic.go
@@ -411,7 +411,7 @@ func (i *TiDBInstance) InitConfig(e executor.TiOpsExecutor, clusterName, cluster
 	if i.IsImported() {
 		configPath := ClusterPath(
 			clusterName,
-			"config",
+			AnsibleImportedConfigPath,
 			fmt.Sprintf(
 				"%s-%s-%d.toml",
 				i.ComponentName(),
@@ -519,7 +519,7 @@ func (i *TiKVInstance) InitConfig(e executor.TiOpsExecutor, clusterName, cluster
 	if i.IsImported() {
 		configPath := ClusterPath(
 			clusterName,
-			"config",
+			AnsibleImportedConfigPath,
 			fmt.Sprintf(
 				"%s-%s-%d.toml",
 				i.ComponentName(),
@@ -640,7 +640,7 @@ func (i *PDInstance) InitConfig(e executor.TiOpsExecutor, clusterName, clusterVe
 	if i.IsImported() {
 		configPath := ClusterPath(
 			clusterName,
-			"config",
+			AnsibleImportedConfigPath,
 			fmt.Sprintf(
 				"%s-%s-%d.toml",
 				i.ComponentName(),
@@ -946,7 +946,7 @@ func (i *TiFlashInstance) InitConfig(e executor.TiOpsExecutor, clusterName, clus
 	if i.IsImported() {
 		configPath := ClusterPath(
 			clusterName,
-			"config",
+			AnsibleImportedConfigPath,
 			fmt.Sprintf(
 				"%s-learner-%s-%d.toml",
 				i.ComponentName(),
@@ -980,7 +980,7 @@ func (i *TiFlashInstance) InitConfig(e executor.TiOpsExecutor, clusterName, clus
 	if i.IsImported() {
 		configPath := ClusterPath(
 			clusterName,
-			"config",
+			AnsibleImportedConfigPath,
 			fmt.Sprintf(
 				"%s-%s-%d.toml",
 				i.ComponentName(),

--- a/pkg/meta/logic.go
+++ b/pkg/meta/logic.go
@@ -421,11 +421,6 @@ func (i *TiDBInstance) InitConfig(e executor.TiOpsExecutor, clusterName, cluster
 		)
 		importConfig, err := ioutil.ReadFile(configPath)
 		if err != nil {
-			if os.IsNotExist(err) {
-				dirPath := ClusterPath(clusterName)
-				log.Errorf("%s, you may try to rename '%s/config' to '%s/%s'",
-					err, dirPath, dirPath, AnsibleImportedConfigPath)
-			}
 			return err
 		}
 		mergedConfig, err := mergeImported(importConfig, spec.Config)
@@ -534,11 +529,6 @@ func (i *TiKVInstance) InitConfig(e executor.TiOpsExecutor, clusterName, cluster
 		)
 		importConfig, err := ioutil.ReadFile(configPath)
 		if err != nil {
-			if os.IsNotExist(err) {
-				dirPath := ClusterPath(clusterName)
-				log.Errorf("%s, you may try to rename '%s/config' to '%s/%s'",
-					err, dirPath, dirPath, AnsibleImportedConfigPath)
-			}
 			return err
 		}
 		mergedConfig, err := mergeImported(importConfig, spec.Config)
@@ -660,11 +650,6 @@ func (i *PDInstance) InitConfig(e executor.TiOpsExecutor, clusterName, clusterVe
 		)
 		importConfig, err := ioutil.ReadFile(configPath)
 		if err != nil {
-			if os.IsNotExist(err) {
-				dirPath := ClusterPath(clusterName)
-				log.Errorf("%s, you may try to rename '%s/config' to '%s/%s'",
-					err, dirPath, dirPath, AnsibleImportedConfigPath)
-			}
 			return err
 		}
 		mergedConfig, err := mergeImported(importConfig, spec.Config)
@@ -971,11 +956,6 @@ func (i *TiFlashInstance) InitConfig(e executor.TiOpsExecutor, clusterName, clus
 		)
 		importConfig, err := ioutil.ReadFile(configPath)
 		if err != nil {
-			if os.IsNotExist(err) {
-				dirPath := ClusterPath(clusterName)
-				log.Errorf("%s, you may try to rename '%s/config' to '%s/%s'",
-					err, dirPath, dirPath, AnsibleImportedConfigPath)
-			}
 			return err
 		}
 		mergedConfig, err := mergeImported(importConfig, spec.LearnerConfig)
@@ -1010,11 +990,6 @@ func (i *TiFlashInstance) InitConfig(e executor.TiOpsExecutor, clusterName, clus
 		)
 		importConfig, err := ioutil.ReadFile(configPath)
 		if err != nil {
-			if os.IsNotExist(err) {
-				dirPath := ClusterPath(clusterName)
-				log.Errorf("%s, you may try to rename '%s/config' to '%s/%s'",
-					err, dirPath, dirPath, AnsibleImportedConfigPath)
-			}
 			return err
 		}
 		specConfig, err = mergeImported(importConfig, spec.Config)

--- a/pkg/meta/logic.go
+++ b/pkg/meta/logic.go
@@ -421,6 +421,11 @@ func (i *TiDBInstance) InitConfig(e executor.TiOpsExecutor, clusterName, cluster
 		)
 		importConfig, err := ioutil.ReadFile(configPath)
 		if err != nil {
+			if os.IsNotExist(err) {
+				dirPath := ClusterPath(clusterName)
+				log.Errorf("%s, you may try to rename '%s/config' to '%s/%s'",
+					err, dirPath, dirPath, AnsibleImportedConfigPath)
+			}
 			return err
 		}
 		mergedConfig, err := mergeImported(importConfig, spec.Config)
@@ -529,6 +534,11 @@ func (i *TiKVInstance) InitConfig(e executor.TiOpsExecutor, clusterName, cluster
 		)
 		importConfig, err := ioutil.ReadFile(configPath)
 		if err != nil {
+			if os.IsNotExist(err) {
+				dirPath := ClusterPath(clusterName)
+				log.Errorf("%s, you may try to rename '%s/config' to '%s/%s'",
+					err, dirPath, dirPath, AnsibleImportedConfigPath)
+			}
 			return err
 		}
 		mergedConfig, err := mergeImported(importConfig, spec.Config)
@@ -650,6 +660,11 @@ func (i *PDInstance) InitConfig(e executor.TiOpsExecutor, clusterName, clusterVe
 		)
 		importConfig, err := ioutil.ReadFile(configPath)
 		if err != nil {
+			if os.IsNotExist(err) {
+				dirPath := ClusterPath(clusterName)
+				log.Errorf("%s, you may try to rename '%s/config' to '%s/%s'",
+					err, dirPath, dirPath, AnsibleImportedConfigPath)
+			}
 			return err
 		}
 		mergedConfig, err := mergeImported(importConfig, spec.Config)
@@ -956,6 +971,11 @@ func (i *TiFlashInstance) InitConfig(e executor.TiOpsExecutor, clusterName, clus
 		)
 		importConfig, err := ioutil.ReadFile(configPath)
 		if err != nil {
+			if os.IsNotExist(err) {
+				dirPath := ClusterPath(clusterName)
+				log.Errorf("%s, you may try to rename '%s/config' to '%s/%s'",
+					err, dirPath, dirPath, AnsibleImportedConfigPath)
+			}
 			return err
 		}
 		mergedConfig, err := mergeImported(importConfig, spec.LearnerConfig)
@@ -990,6 +1010,11 @@ func (i *TiFlashInstance) InitConfig(e executor.TiOpsExecutor, clusterName, clus
 		)
 		importConfig, err := ioutil.ReadFile(configPath)
 		if err != nil {
+			if os.IsNotExist(err) {
+				dirPath := ClusterPath(clusterName)
+				log.Errorf("%s, you may try to rename '%s/config' to '%s/%s'",
+					err, dirPath, dirPath, AnsibleImportedConfigPath)
+			}
 			return err
 		}
 		specConfig, err = mergeImported(importConfig, spec.Config)

--- a/pkg/meta/logic_dm.go
+++ b/pkg/meta/logic_dm.go
@@ -272,7 +272,7 @@ func (i *DMMasterInstance) InitConfig(e executor.TiOpsExecutor, clusterName, clu
 	if i.IsImported() {
 		configPath := ClusterPath(
 			clusterName,
-			"config",
+			AnsibleImportedConfigPath,
 			fmt.Sprintf(
 				"%s-%s-%d.toml",
 				i.ComponentName(),
@@ -382,7 +382,7 @@ func (i *DMWorkerInstance) InitConfig(e executor.TiOpsExecutor, clusterName, clu
 	if i.IsImported() {
 		configPath := ClusterPath(
 			clusterName,
-			"config",
+			AnsibleImportedConfigPath,
 			fmt.Sprintf(
 				"%s-%s-%d.toml",
 				i.ComponentName(),

--- a/pkg/meta/logic_dm.go
+++ b/pkg/meta/logic_dm.go
@@ -24,6 +24,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/pingcap-incubator/tiup-cluster/pkg/clusterutil"
 	"github.com/pingcap-incubator/tiup-cluster/pkg/executor"
+	"github.com/pingcap-incubator/tiup-cluster/pkg/log"
 	"github.com/pingcap-incubator/tiup-cluster/pkg/template/scripts"
 	system "github.com/pingcap-incubator/tiup-cluster/pkg/template/systemd"
 	"github.com/pingcap/errors"
@@ -282,6 +283,11 @@ func (i *DMMasterInstance) InitConfig(e executor.TiOpsExecutor, clusterName, clu
 		)
 		importConfig, err := ioutil.ReadFile(configPath)
 		if err != nil {
+			if os.IsNotExist(err) {
+				dirPath := ClusterPath(clusterName)
+				log.Errorf("%s, you may try to rename '%s/config' to '%s/%s'",
+					err, dirPath, dirPath, AnsibleImportedConfigPath)
+			}
 			return err
 		}
 		mergedConfig, err := mergeImported(importConfig, spec.Config)
@@ -392,6 +398,11 @@ func (i *DMWorkerInstance) InitConfig(e executor.TiOpsExecutor, clusterName, clu
 		)
 		importConfig, err := ioutil.ReadFile(configPath)
 		if err != nil {
+			if os.IsNotExist(err) {
+				dirPath := ClusterPath(clusterName)
+				log.Errorf("%s, you may try to rename '%s/config' to '%s/%s'",
+					err, dirPath, dirPath, AnsibleImportedConfigPath)
+			}
 			return err
 		}
 		mergedConfig, err := mergeImported(importConfig, spec.Config)

--- a/pkg/meta/logic_dm.go
+++ b/pkg/meta/logic_dm.go
@@ -24,7 +24,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/pingcap-incubator/tiup-cluster/pkg/clusterutil"
 	"github.com/pingcap-incubator/tiup-cluster/pkg/executor"
-	"github.com/pingcap-incubator/tiup-cluster/pkg/log"
 	"github.com/pingcap-incubator/tiup-cluster/pkg/template/scripts"
 	system "github.com/pingcap-incubator/tiup-cluster/pkg/template/systemd"
 	"github.com/pingcap/errors"
@@ -283,11 +282,6 @@ func (i *DMMasterInstance) InitConfig(e executor.TiOpsExecutor, clusterName, clu
 		)
 		importConfig, err := ioutil.ReadFile(configPath)
 		if err != nil {
-			if os.IsNotExist(err) {
-				dirPath := ClusterPath(clusterName)
-				log.Errorf("%s, you may try to rename '%s/config' to '%s/%s'",
-					err, dirPath, dirPath, AnsibleImportedConfigPath)
-			}
 			return err
 		}
 		mergedConfig, err := mergeImported(importConfig, spec.Config)
@@ -398,11 +392,6 @@ func (i *DMWorkerInstance) InitConfig(e executor.TiOpsExecutor, clusterName, clu
 		)
 		importConfig, err := ioutil.ReadFile(configPath)
 		if err != nil {
-			if os.IsNotExist(err) {
-				dirPath := ClusterPath(clusterName)
-				log.Errorf("%s, you may try to rename '%s/config' to '%s/%s'",
-					err, dirPath, dirPath, AnsibleImportedConfigPath)
-			}
 			return err
 		}
 		mergedConfig, err := mergeImported(importConfig, spec.Config)

--- a/pkg/meta/pump.go
+++ b/pkg/meta/pump.go
@@ -109,7 +109,7 @@ func (i *PumpInstance) InitConfig(e executor.TiOpsExecutor, clusterName, cluster
 	if i.IsImported() {
 		configPath := ClusterPath(
 			clusterName,
-			"config",
+			AnsibleImportedConfigPath,
 			fmt.Sprintf(
 				"%s-%s-%d.toml",
 				i.ComponentName(),

--- a/pkg/meta/pump.go
+++ b/pkg/meta/pump.go
@@ -16,10 +16,12 @@ package meta
 import (
 	"fmt"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strconv"
 
 	"github.com/pingcap-incubator/tiup-cluster/pkg/executor"
+	"github.com/pingcap-incubator/tiup-cluster/pkg/log"
 	"github.com/pingcap-incubator/tiup-cluster/pkg/template/scripts"
 )
 
@@ -119,6 +121,11 @@ func (i *PumpInstance) InitConfig(e executor.TiOpsExecutor, clusterName, cluster
 		)
 		importConfig, err := ioutil.ReadFile(configPath)
 		if err != nil {
+			if os.IsNotExist(err) {
+				dirPath := ClusterPath(clusterName)
+				log.Errorf("%s, you may try to rename '%s/config' to '%s/%s'",
+					err, dirPath, dirPath, AnsibleImportedConfigPath)
+			}
 			return err
 		}
 		mergedConfig, err := mergeImported(importConfig, spec.Config)

--- a/pkg/meta/pump.go
+++ b/pkg/meta/pump.go
@@ -16,12 +16,10 @@ package meta
 import (
 	"fmt"
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"strconv"
 
 	"github.com/pingcap-incubator/tiup-cluster/pkg/executor"
-	"github.com/pingcap-incubator/tiup-cluster/pkg/log"
 	"github.com/pingcap-incubator/tiup-cluster/pkg/template/scripts"
 )
 
@@ -121,11 +119,6 @@ func (i *PumpInstance) InitConfig(e executor.TiOpsExecutor, clusterName, cluster
 		)
 		importConfig, err := ioutil.ReadFile(configPath)
 		if err != nil {
-			if os.IsNotExist(err) {
-				dirPath := ClusterPath(clusterName)
-				log.Errorf("%s, you may try to rename '%s/config' to '%s/%s'",
-					err, dirPath, dirPath, AnsibleImportedConfigPath)
-			}
 			return err
 		}
 		mergedConfig, err := mergeImported(importConfig, spec.Config)

--- a/pkg/meta/server_config.go
+++ b/pkg/meta/server_config.go
@@ -28,6 +28,8 @@ import (
 const (
 	// AnsibleImportedConfigPath is the sub path where all imported configs are stored
 	AnsibleImportedConfigPath = "ansible-imported-configs"
+	// TempConfigPath is the sub path where generated temporary configs are stored
+	TempConfigPath = "config-cache"
 )
 
 // strKeyMap tries to convert `map[interface{}]interface{}` to `map[string]interface{}`

--- a/pkg/meta/server_config.go
+++ b/pkg/meta/server_config.go
@@ -16,12 +16,15 @@ package meta
 import (
 	"bytes"
 	"fmt"
+	"os"
 	"path"
 	"reflect"
 	"strings"
 
 	"github.com/BurntSushi/toml"
 	"github.com/pingcap-incubator/tiup-cluster/pkg/executor"
+	"github.com/pingcap-incubator/tiup-cluster/pkg/log"
+	"github.com/pingcap-incubator/tiup-cluster/pkg/utils"
 	"github.com/pingcap/errors"
 )
 
@@ -30,6 +33,8 @@ const (
 	AnsibleImportedConfigPath = "ansible-imported-configs"
 	// TempConfigPath is the sub path where generated temporary configs are stored
 	TempConfigPath = "config-cache"
+	// migrateLockName is the directory name of migrating lock
+	migrateLockName = "tiup-migrate.lck"
 )
 
 // strKeyMap tries to convert `map[interface{}]interface{}` to `map[string]interface{}`
@@ -183,4 +188,40 @@ func checkConfig(e executor.TiOpsExecutor, componentName, clusterVersion, config
 func hasConfigCheckFlag(e executor.TiOpsExecutor, binPath string) bool {
 	stdout, stderr, _ := e.Execute(fmt.Sprintf("%s --help", binPath), false)
 	return strings.Contains(string(stdout), "config-check") || strings.Contains(string(stderr), "config-check")
+}
+
+// HandleImportPathMigration tries to rename old configs file directory for imported clusters to the new name
+func HandleImportPathMigration(clsName string) error {
+	dirPath := ClusterPath(clsName)
+	targetPath := path.Join(dirPath, AnsibleImportedConfigPath)
+	_, err := os.Stat(targetPath)
+	if os.IsNotExist(err) {
+		log.Warnf("renaming '%s/config' to '%s'", dirPath, targetPath)
+
+		if lckErr := utils.Retry(func() error {
+			_, lckErr := os.Stat(path.Join(dirPath, migrateLockName))
+			if os.IsNotExist(lckErr) {
+				return nil
+			}
+			return errors.Errorf("config dir already lock by another task, %s", lckErr)
+		}); lckErr != nil {
+			return lckErr
+		}
+		if lckErr := os.Mkdir(path.Join(dirPath, migrateLockName), 0755); lckErr != nil {
+			return errors.Errorf("can not lock config dir, %s", lckErr)
+		}
+		defer func() {
+			rmErr := os.Remove(path.Join(dirPath, migrateLockName))
+			if rmErr != nil {
+				log.Errorf("error unlocking config dir, %s", rmErr)
+			}
+		}()
+
+		// ignore if the old config path does not exist
+		if _, err := os.Stat(path.Join(dirPath, "config")); os.IsNotExist(err) {
+			return nil
+		}
+		return os.Rename(path.Join(dirPath, "config"), targetPath)
+	}
+	return nil
 }

--- a/pkg/meta/server_config.go
+++ b/pkg/meta/server_config.go
@@ -25,6 +25,11 @@ import (
 	"github.com/pingcap/errors"
 )
 
+const (
+	// AnsibleImportedConfigPath is the sub path where all imported configs are stored
+	AnsibleImportedConfigPath = "ansible-imported-configs"
+)
+
 // strKeyMap tries to convert `map[interface{}]interface{}` to `map[string]interface{}`
 func strKeyMap(val interface{}) interface{} {
 	m, ok := val.(map[interface{}]interface{})
@@ -111,7 +116,7 @@ func merge2Toml(comp string, global, overwrite map[string]interface{}) ([]byte, 
 		return nil, errors.AddStack(err)
 	}
 
-	buf := bytes.NewBufferString(fmt.Sprintf(`# WARNING: This file was auto-generated. Do not edit! All your edit might be overwritten!
+	buf := bytes.NewBufferString(fmt.Sprintf(`# WARNING: This file is auto-generated. Do not edit! All your modification will be overwritten!
 # You can use 'tiup cluster edit-config' and 'tiup cluster reload' to update the configuration
 # All configuration items you want to change can be added to:
 # server_configs:
@@ -135,7 +140,7 @@ func mergeImported(importConfig []byte, specConfig map[string]interface{}) (map[
 		return specConfig, errors.Trace(err)
 	}
 
-	// overwrite topology specifieced configs to the imported configs
+	// overwrite topology specifieced configs upon the imported configs
 	lhs, err := merge(configData, specConfig)
 	if err != nil {
 		return specConfig, errors.Trace(err)

--- a/pkg/meta/topology_test.go
+++ b/pkg/meta/topology_test.go
@@ -400,7 +400,7 @@ tikv_servers:
 
 `), &topo)
 	c.Assert(err, IsNil)
-	expected := `# WARNING: This file was auto-generated. Do not edit! All your edit might be overwritten!
+	expected := `# WARNING: This file is auto-generated. Do not edit! All your modification will be overwritten!
 # You can use 'tiup cluster edit-config' and 'tiup cluster reload' to update the configuration
 # All configuration items you want to change can be added to:
 # server_configs:
@@ -473,7 +473,7 @@ tikv_servers:
   - host: 172.19.0.103
 `), &topo)
 	c.Assert(err, IsNil)
-	expected := `# WARNING: This file was auto-generated. Do not edit! All your edit might be overwritten!
+	expected := `# WARNING: This file is auto-generated. Do not edit! All your modification will be overwritten!
 # You can use 'tiup cluster edit-config' and 'tiup cluster reload' to update the configuration
 # All configuration items you want to change can be added to:
 # server_configs:
@@ -547,7 +547,7 @@ itemy = 999
 item7 = 780
 `)
 
-	expected := `# WARNING: This file was auto-generated. Do not edit! All your edit might be overwritten!
+	expected := `# WARNING: This file is auto-generated. Do not edit! All your modification will be overwritten!
 # You can use 'tiup cluster edit-config' and 'tiup cluster reload' to update the configuration
 # All configuration items you want to change can be added to:
 # server_configs:

--- a/pkg/task/init_config.go
+++ b/pkg/task/init_config.go
@@ -59,5 +59,5 @@ func (c *InitConfig) Rollback(ctx *Context) error {
 func (c *InitConfig) String() string {
 	return fmt.Sprintf("InitConfig: cluster=%s, user=%s, host=%s, path=%s, %s",
 		c.clusterName, c.deployUser, c.instance.GetHost(),
-		filepath.Join(meta.ClusterPath(c.clusterName, "config", c.instance.ServiceName())), c.paths)
+		filepath.Join(meta.ClusterPath(c.clusterName, meta.TempConfigPath, c.instance.ServiceName())), c.paths)
 }

--- a/pkg/task/scale_config.go
+++ b/pkg/task/scale_config.go
@@ -38,7 +38,7 @@ func (c *ScaleConfig) Execute(ctx *Context) error {
 		return ErrNoExecutor
 	}
 
-	c.paths.Cache = meta.ClusterPath(c.clusterName, "config")
+	c.paths.Cache = meta.ClusterPath(c.clusterName, meta.TempConfigPath)
 	if err := os.MkdirAll(c.paths.Cache, 0755); err != nil {
 		return err
 	}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -45,7 +45,7 @@ type RetryOption struct {
 
 // default values for RetryOption
 var (
-	defaultAttempts int64 = 10
+	defaultAttempts int64 = 20
 	defaultDelay          = time.Millisecond * 500 // 500ms
 	defaultTimeout        = time.Second * 10       // 10s
 )


### PR DESCRIPTION
When generating configs for instances, we used a cache dir to store them before transferring to deployment server. However, the same dir is also used to store configs imported from ansible deployment.

If the default configs was modified when it was managed by ansible, and them after importing to tiup cluster, modified again with `edit-config`, the former modifications are overwritten by new default ones (for sections of the same key, other sections are kept the same but rewritten to file with the new template format). It also makes the new global configs not applying to final config files.

Also fixed the backup logic to ignore file not found error. For imported clusters, multiple instances is very likely to share the same deploy dir, and only the 1st backup attempts will success, others can safely be ignored.