### PR TITLE
Bugfix: lengthy monitor log dir

### DIFF
--- a/pkg/meta/topology.go
+++ b/pkg/meta/topology.go
@@ -615,7 +615,8 @@ func (topo *TopologySpecification) UnmarshalYAML(unmarshal func(interface{}) err
 	if topo.MonitoredOptions.LogDir == "" {
 		topo.MonitoredOptions.LogDir = "log"
 	}
-	if !strings.HasPrefix(topo.MonitoredOptions.LogDir, "/") {
+	if !strings.HasPrefix(topo.MonitoredOptions.LogDir, "/") &&
+		!strings.HasPrefix(topo.MonitoredOptions.LogDir, topo.MonitoredOptions.DeployDir) {
 		topo.MonitoredOptions.LogDir = filepath.Join(topo.MonitoredOptions.DeployDir, topo.MonitoredOptions.LogDir)
 	}
 


### PR DESCRIPTION
The monitor directory will contains double deploy directory if it
doesn't start with / and has deploy directory as prefix, this is
not correct.

Signed-off-by: lucklove <gnu.crazier@gmail.com>