### PR TITLE
Increase default threads of TiFlash's raftstore

### DIFF
--- a/examples/topology.example.yaml
+++ b/examples/topology.example.yaml
@@ -61,6 +61,8 @@ server_configs:
     logger.level: "info"
   tiflash-learner:
     log-level: "info"
+    # raftstore.apply-pool-size: 4
+    # raftstore.store-pool-size: 4
   pump:
     gc: 7
 
@@ -155,6 +157,8 @@ tiflash_servers:
     # # The following configs are used to overwrite the `server_configs.tiflash-learner` values.
     # learner_config:
     #   log-level: "info"
+    #   raftstore.apply-pool-size: 4
+    #   raftstore.store-pool-size: 4
   - host: 10.0.1.15
   - host: 10.0.1.16
 

--- a/pkg/meta/logic.go
+++ b/pkg/meta/logic.go
@@ -875,23 +875,16 @@ server_configs:
     security.ca-path: ""
     security.cert-path: ""
     security.key-path: ""
+    # Normally the number of TiFlash nodes is smaller than TiKV nodes, and we need more raft threads to match the write speed of TiKV.
+    raftstore.apply-pool-size: 4
+    raftstore.store-pool-size: 4
 `, cfg.LogDir, cfg.IP, cfg.FlashServicePort, cfg.FlashProxyPort, cfg.FlashProxyStatusPort, firstDataDir)), &topo)
 
 	if err != nil {
 		return nil, err
 	}
 
-	// Normally the number of TiFlash nodes is smaller than TiKV nodes, and we need more raft threads to match the write speed of TiKV.
-	defaultConfigurations := make(map[string]interface{})
-	defaultConfigurations["raftstore.apply-pool-size"] = 4
-	defaultConfigurations["raftstore.store-pool-size"] = 4
-
-	conf, err := merge(defaultConfigurations, topo.ServerConfigs.TiFlashLearner)
-	if err != nil {
-		return nil, err
-	}
-
-	conf, err = merge(conf, src)
+	conf, err := merge(topo.ServerConfigs.TiFlashLearner, src)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/meta/logic.go
+++ b/pkg/meta/logic.go
@@ -881,7 +881,17 @@ server_configs:
 		return nil, err
 	}
 
-	conf, err := merge(topo.ServerConfigs.TiFlashLearner, src)
+	// Normally the number of TiFlash nodes is smaller than TiKV nodes, and we need more raft threads to match the write speed of TiKV.
+	defaultConfigurations := make(map[string]interface{})
+	defaultConfigurations["raftstore.apply-pool-size"] = 4
+	defaultConfigurations["raftstore.store-pool-size"] = 4
+
+	conf, err := merge(defaultConfigurations, topo.ServerConfigs.TiFlashLearner)
+	if err != nil {
+		return nil, err
+	}
+
+	conf, err = merge(conf, src)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Signed-off-by: JaySon-Huang <tshent@qq.com>

Normally the number of TiFlash nodes is smaller than TiKV nodes, and we need more raft threads to match the write speed of TiKV. 
This PR set raftstore.{apply-pool-size,store-pool-size} to 4 for TiFlash's learner by default.