### PR TITLE
TiFlash: Check max replicas

### DIFF
--- a/pkg/operation/scale_in.go
+++ b/pkg/operation/scale_in.go
@@ -187,7 +187,7 @@ func ScaleInCluster(
 		maxReplicas := config.MaxReplicas
 
 		if len(tikvInstances) < maxReplicas {
-			return fmt.Errorf("max-replicas will be more than tikv instances after scale-in. TiFlash will be unable to receive data from leader")
+			log.Warnf(fmt.Sprintf("max-replicas will be more than tikv instance number %d after scale-in. TiFlash will be unable to receive data from leader until tikv instance number reach %d", len(tikvInstances), maxReplicas))
 		}
 	}
 

--- a/pkg/operation/scale_in.go
+++ b/pkg/operation/scale_in.go
@@ -187,7 +187,7 @@ func ScaleInCluster(
 		maxReplicas := config.MaxReplicas
 
 		if len(tikvInstances) < maxReplicas {
-			log.Warnf(fmt.Sprintf("max-replicas will be more than tikv instance number %d after scale-in. TiFlash will be unable to receive data from leader until tikv instance number reach %d", len(tikvInstances), maxReplicas))
+			log.Warnf(fmt.Sprintf("TiKV instance number %d will be less than max-replicas setting after scale-in. TiFlash won't be able to receive data from leader before TiKV instance number reach %d", len(tikvInstances), maxReplicas))
 		}
 	}
 


### PR DESCRIPTION
Check max-replicas before scale-in. Gives a warning that TiFlash will not be working before TiKV instance number reaches max-replicas.

Manually tested.