### PR TITLE
Initconfig for upgrade

### DIFF
--- a/cmd/cluster/command/upgrade.go
+++ b/cmd/cluster/command/upgrade.go
@@ -125,23 +125,23 @@ func upgrade(clusterName, clusterVersion string, opt operator.Options) error {
 					tb.BackupComponent(inst.ComponentName(), metadata.Version, inst.GetHost(), deployDir).
 						CopyComponent(inst.ComponentName(), inst.OS(), inst.Arch(), version, inst.GetHost(), deployDir)
 				}
-				tb.InitConfig(
-					clusterName,
-					clusterVersion,
-					inst,
-					metadata.User,
-					meta.DirPaths{
-						Deploy: deployDir,
-						Data:   dataDirs,
-						Log:    logDir,
-						Cache:  meta.ClusterPath(clusterName, meta.TempConfigPath),
-					},
-				)
 				hasImported = true
 			} else {
 				tb.BackupComponent(inst.ComponentName(), metadata.Version, inst.GetHost(), deployDir).
 					CopyComponent(inst.ComponentName(), inst.OS(), inst.Arch(), version, inst.GetHost(), deployDir)
 			}
+			tb.InitConfig(
+				clusterName,
+				clusterVersion,
+				inst,
+				metadata.User,
+				meta.DirPaths{
+					Deploy: deployDir,
+					Data:   dataDirs,
+					Log:    logDir,
+					Cache:  meta.ClusterPath(clusterName, meta.TempConfigPath),
+				},
+			)
 			copyCompTasks = append(copyCompTasks, tb.Build())
 		}
 	}


### PR DESCRIPTION
fix #411


test: 
- deploy v1 cluster and start it
- edit-config add some config
- upgrade v1 to v2
- check config take exists in the dst node of the component.